### PR TITLE
Add state register entity with configuration classes

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -1,26 +1,20 @@
 using Microsoft.EntityFrameworkCore;
 using PoverkaWinForms.Domain;
+using PoverkaWinForms.Data.Configurations;
 
 namespace PoverkaWinForms.Data
 {
     public class AppDbContext : DbContext
     {
         public DbSet<TestRun> TestRuns => Set<TestRun>();
+        public DbSet<StateRegister> StateRegisters => Set<StateRegister>();
 
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            var e = modelBuilder.Entity<TestRun>();
-            e.HasKey(x => x.Id);
-            e.Property(x => x.Timestamp).HasColumnType("timestamp");
-            e.OwnsOne(x => x.Meter, b =>
-            {
-                b.Property(m => m.Serial).HasColumnName("Meter_Serial").HasMaxLength(128);
-                b.Property(m => m.Model).HasColumnName("Meter_Model").HasMaxLength(128);
-                b.Property(m => m.DiameterMm).HasColumnName("Meter_DiameterMm");
-                b.Property(m => m.Unit).HasColumnName("Meter_Unit").HasMaxLength(32);
-            });
+            modelBuilder.ApplyConfiguration(new TestRunConfiguration());
+            modelBuilder.ApplyConfiguration(new StateRegisterConfiguration());
         }
     }
 }

--- a/Data/Configurations/StateRegisterConfiguration.cs
+++ b/Data/Configurations/StateRegisterConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PoverkaWinForms.Domain;
+
+namespace PoverkaWinForms.Data.Configurations
+{
+    public class StateRegisterConfiguration : IEntityTypeConfiguration<StateRegister>
+    {
+        public void Configure(EntityTypeBuilder<StateRegister> builder)
+        {
+            builder.ToTable("StateRegisters");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.Id).HasColumnName("Id");
+            builder.Property(x => x.RegisterNumber).HasColumnName("RegisterNumber").HasMaxLength(128);
+            builder.Property(x => x.InstrumentName).HasColumnName("InstrumentName").HasMaxLength(256);
+            builder.Property(x => x.VerificationDocument).HasColumnName("VerificationDocument").HasMaxLength(256);
+        }
+    }
+}

--- a/Data/Configurations/TestRunConfiguration.cs
+++ b/Data/Configurations/TestRunConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PoverkaWinForms.Domain;
+
+namespace PoverkaWinForms.Data.Configurations
+{
+    public class TestRunConfiguration : IEntityTypeConfiguration<TestRun>
+    {
+        public void Configure(EntityTypeBuilder<TestRun> builder)
+        {
+            builder.ToTable("TestRuns");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.Id).HasColumnName("Id");
+            builder.Property(x => x.Timestamp).HasColumnName("Timestamp").HasColumnType("timestamp");
+            builder.Property(x => x.VolumeLiters).HasColumnName("VolumeLiters");
+            builder.Property(x => x.TimeSeconds).HasColumnName("TimeSeconds");
+            builder.Property(x => x.IndicatedFlow).HasColumnName("IndicatedFlow");
+            builder.Property(x => x.TemperatureC).HasColumnName("TemperatureC");
+            builder.Property(x => x.PressureKPa).HasColumnName("PressureKPa");
+            builder.Property(x => x.ActualFlow).HasColumnName("ActualFlow");
+            builder.Property(x => x.ErrorPercent).HasColumnName("ErrorPercent");
+
+            builder.OwnsOne(x => x.Meter, b =>
+            {
+                b.Property(m => m.Serial).HasColumnName("MeterSerial").HasMaxLength(128);
+                b.Property(m => m.Model).HasColumnName("MeterModel").HasMaxLength(128);
+                b.Property(m => m.DiameterMm).HasColumnName("MeterDiameterMm");
+                b.Property(m => m.Unit).HasColumnName("MeterUnit").HasMaxLength(32);
+            });
+        }
+    }
+}

--- a/Domain/StateRegister.cs
+++ b/Domain/StateRegister.cs
@@ -1,0 +1,23 @@
+namespace PoverkaWinForms.Domain
+{
+    public class StateRegister
+    {
+        public int Id { get; set; }
+        public string RegisterNumber { get; set; }
+        public string InstrumentName { get; set; }
+        public string VerificationDocument { get; set; }
+
+        public StateRegister(string registerNumber, string instrumentName, string verificationDocument)
+        {
+            RegisterNumber = registerNumber;
+            InstrumentName = instrumentName;
+            VerificationDocument = verificationDocument;
+        }
+
+#pragma warning disable CS8618
+        private StateRegister()
+        {
+        }
+#pragma warning restore CS8618
+    }
+}

--- a/Services/EfRepository.cs
+++ b/Services/EfRepository.cs
@@ -24,6 +24,14 @@ namespace PoverkaWinForms.Services
                 .ToList();
         }
 
+        public List<TestRun> GetBySerial(string serial)
+        {
+            return _db.TestRuns.AsNoTracking()
+                .Where(r => r.Meter.Serial == serial)
+                .OrderByDescending(r => r.Timestamp)
+                .ToList();
+        }
+
         public void Add(TestRun run)
         {
             _db.TestRuns.Add(run);

--- a/Services/IRunRepository.cs
+++ b/Services/IRunRepository.cs
@@ -6,6 +6,7 @@ namespace PoverkaWinForms.Services
     public interface IRunRepository
     {
         List<TestRun> GetAll();
+        List<TestRun> GetBySerial(string serial);
         void Add(TestRun run);
         void ReplaceAll(List<TestRun> runs);
     }

--- a/Services/IStateRegisterRepository.cs
+++ b/Services/IStateRegisterRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using PoverkaWinForms.Domain;
+
+namespace PoverkaWinForms.Services
+{
+    public interface IStateRegisterRepository
+    {
+        List<StateRegister> GetAll();
+        StateRegister? GetByRegisterNumber(string registerNumber);
+    }
+}

--- a/Services/JsonRepository.cs
+++ b/Services/JsonRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using PoverkaWinForms.Domain;
 
@@ -24,6 +25,14 @@ namespace PoverkaWinForms.Services
             if (!File.Exists(_path)) return new List<TestRun>();
             var json = File.ReadAllText(_path);
             return JsonSerializer.Deserialize<List<TestRun>>(json) ?? new List<TestRun>();
+        }
+
+        public List<TestRun> GetBySerial(string serial)
+        {
+            return GetAll()
+                .Where(r => r.Meter.Serial == serial)
+                .OrderByDescending(r => r.Timestamp)
+                .ToList();
         }
 
         public void ReplaceAll(List<TestRun> runs)

--- a/Services/StateRegisterRepository.cs
+++ b/Services/StateRegisterRepository.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using PoverkaWinForms.Data;
+using PoverkaWinForms.Domain;
+
+namespace PoverkaWinForms.Services
+{
+    public class StateRegisterRepository : IStateRegisterRepository
+    {
+        private readonly AppDbContext _db;
+
+        public StateRegisterRepository(AppDbContext db)
+        {
+            _db = db;
+            _db.Database.EnsureCreated();
+        }
+
+        public List<StateRegister> GetAll()
+        {
+            return _db.StateRegisters.AsNoTracking().ToList();
+        }
+
+        public StateRegister? GetByRegisterNumber(string registerNumber)
+        {
+            return _db.StateRegisters.AsNoTracking()
+                .FirstOrDefault(r => r.RegisterNumber == registerNumber);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `StateRegister` domain entity with constructor-based initialization
- move EF mappings to dedicated configuration classes with PascalCase table and column names

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a43bdaf16883319ee559b787968afe