### PR TITLE
Add meter settings form

### DIFF
--- a/Forms/MeterConfigControl.cs
+++ b/Forms/MeterConfigControl.cs
@@ -1,0 +1,71 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace PoverkaWinForms.Forms
+{
+    /// <summary>
+    /// Control for entering settings of a single flow meter.
+    /// </summary>
+    public class MeterConfigControl : GroupBox
+    {
+        private readonly CheckBox _chkEnabled;
+        private readonly TableLayoutPanel _layout;
+
+        public MeterConfigControl()
+        {
+            Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            Size = new Size(250, 170);
+
+            _chkEnabled = new CheckBox
+            {
+                Text = "Включить",
+                AutoSize = true,
+                Checked = true,
+                Anchor = AnchorStyles.Top | AnchorStyles.Right,
+                Location = new Point(Width - 85, -2)
+            };
+            Controls.Add(_chkEnabled);
+
+            _layout = new TableLayoutPanel
+            {
+                ColumnCount = 2,
+                RowCount = 5,
+                Dock = DockStyle.Fill,
+                Location = new Point(3, 19),
+                Padding = new Padding(3),
+            };
+
+            _layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 40F));
+            _layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 60F));
+            for (int i = 0; i < 5; i++)
+            {
+                _layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 28F));
+            }
+
+            AddField("Производитель", out var txtMan);
+            AddField("Тип", out var txtType);
+            AddField("Заводской номер", out var txtSerial);
+            AddField("Методика СИ", out var txtMethod);
+            AddField("Документ на поверку", out var txtDoc);
+
+            Controls.Add(_layout);
+
+            _chkEnabled.CheckedChanged += (_, _) => _layout.Enabled = _chkEnabled.Checked;
+        }
+
+        private void AddField(string label, out TextBox box)
+        {
+            var lbl = new Label
+            {
+                Text = label,
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleLeft
+            };
+            box = new TextBox { Dock = DockStyle.Fill };
+            int row = _layout.Controls.Count / 2;
+            _layout.Controls.Add(lbl, 0, row);
+            _layout.Controls.Add(box, 1, row);
+        }
+    }
+}
+

--- a/Forms/MeterSettingsForm.cs
+++ b/Forms/MeterSettingsForm.cs
@@ -1,0 +1,69 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace PoverkaWinForms.Forms
+{
+    /// <summary>
+    /// Form with settings for up to six flow meters.
+    /// </summary>
+    public class MeterSettingsForm : Form
+    {
+        public MeterSettingsForm()
+        {
+            Text = "Настройка параметров поверяемых преобразователей";
+            ClientSize = new Size(930, 560);
+            StartPosition = FormStartPosition.CenterScreen;
+
+            var header = new Panel
+            {
+                Dock = DockStyle.Top,
+                Height = 60
+            };
+            Controls.Add(header);
+
+            var lblTitle = new Label
+            {
+                Text = "Настройка параметров поверяемых преобразователей",
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                Font = new Font("Segoe UI", 14F, FontStyle.Regular, GraphicsUnit.Point)
+            };
+            header.Controls.Add(lblTitle);
+
+            var btnTest = new Button
+            {
+                Text = "Тест",
+                AutoSize = true,
+                Anchor = AnchorStyles.Top | AnchorStyles.Right,
+                Location = new Point(header.Width - 80, 15)
+            };
+            header.Controls.Add(btnTest);
+
+            var table = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 3,
+                RowCount = 2,
+                Padding = new Padding(10)
+            };
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
+            table.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            table.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            Controls.Add(table);
+
+            for (int i = 0; i < 6; i++)
+            {
+                var control = new MeterConfigControl
+                {
+                    Text = $"Расходомер №{i + 1}",
+                    Dock = DockStyle.Fill,
+                    Margin = new Padding(6)
+                };
+                table.Controls.Add(control, i % 3, i / 3);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add reusable group box control for entering flow meter parameters
- include form that displays six flow meter configuration blocks

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a447667d50833181dcc0a4c4bcb20b