### PR TITLE
Fix designer parsing issues by simplifying form code

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -61,13 +61,16 @@ namespace PoverkaWinForms
 
         private void btnGenerateReport_Click(object sender, EventArgs e)
         {
-            if (gridResults.CurrentRow?.DataBoundItem is not TestRun run)
+            var current = gridResults.CurrentRow != null
+                ? gridResults.CurrentRow.DataBoundItem as TestRun
+                : null;
+            if (current == null)
             {
                 MessageBox.Show("Выберите запись в таблице результатов.", "Отчёт", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
-            var path = ReportGenerator.SaveRtfTo(_reportsDir, run);
+            var path = ReportGenerator.SaveRtfTo(_reportsDir, current);
             linkLastReport.Text = path;
             linkLastReport.Visible = true;
         }
@@ -84,8 +87,10 @@ namespace PoverkaWinForms
 
         private void btnMetersSetup_Click(object sender, EventArgs e)
         {
-            using var dlg = new MetersSetupForm();
-            dlg.ShowDialog(this);
+            using (var dlg = new MetersSetupForm())
+            {
+                dlg.ShowDialog(this);
+            }
         }
     }
 }

--- a/Forms/MetersSetupForm.cs
+++ b/Forms/MetersSetupForm.cs
@@ -96,8 +96,13 @@ namespace PoverkaWinForms
                 Location = new Point(ClientSize.Width - 85, ClientSize.Height - 40),
                 Anchor = AnchorStyles.Bottom | AnchorStyles.Right
             };
-            btnExit.Click += (_, _) => Close();
+            btnExit.Click += BtnExit_Click;
             Controls.Add(btnExit);
+        }
+
+        private void BtnExit_Click(object sender, EventArgs e)
+        {
+            Close();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace modern pattern-matching and using declaration in MainForm with older constructs compatible with the WinForms designer
- Convert lambda-based exit handler in MetersSetupForm to a dedicated method

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a44b3158548331ab1af1fc9feebe37