### PR TITLE
Recreate meters setup form

### DIFF
--- a/Forms/MetersSetupForm.Designer.cs
+++ b/Forms/MetersSetupForm.Designer.cs
@@ -1,0 +1,1487 @@
+namespace PoverkaWinForms
+{
+    partial class MetersSetupForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
+            this.label7 = new System.Windows.Forms.Label();
+            this.Flow1_Document_CB = new System.Windows.Forms.ComboBox();
+            this.Flow1_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.Flow1_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.Flow1_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.Flow1_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.Flow1_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.GosReestr = new System.Windows.Forms.Label();
+            this.Flow1_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.Rashodomer1_GB = new System.Windows.Forms.GroupBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.Rashodomer1_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer2_GB = new System.Windows.Forms.GroupBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.Flow2_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.label11 = new System.Windows.Forms.Label();
+            this.Flow2_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.Flow2_Document_CB = new System.Windows.Forms.ComboBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.Flow2_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.Flow2_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.label13 = new System.Windows.Forms.Label();
+            this.label14 = new System.Windows.Forms.Label();
+            this.label15 = new System.Windows.Forms.Label();
+            this.Flow2_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label16 = new System.Windows.Forms.Label();
+            this.Flow2_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label17 = new System.Windows.Forms.Label();
+            this.Rashodomer3_GB = new System.Windows.Forms.GroupBox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.Flow3_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.label18 = new System.Windows.Forms.Label();
+            this.Flow3_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.Flow3_Document_CB = new System.Windows.Forms.ComboBox();
+            this.label19 = new System.Windows.Forms.Label();
+            this.Flow3_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.Flow3_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.label20 = new System.Windows.Forms.Label();
+            this.label21 = new System.Windows.Forms.Label();
+            this.label22 = new System.Windows.Forms.Label();
+            this.Flow3_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label23 = new System.Windows.Forms.Label();
+            this.Flow3_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label24 = new System.Windows.Forms.Label();
+            this.Rashodomer4_GB = new System.Windows.Forms.GroupBox();
+            this.label25 = new System.Windows.Forms.Label();
+            this.Flow4_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.label26 = new System.Windows.Forms.Label();
+            this.Flow4_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.Flow4_Document_CB = new System.Windows.Forms.ComboBox();
+            this.label27 = new System.Windows.Forms.Label();
+            this.Flow4_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.Flow4_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.label28 = new System.Windows.Forms.Label();
+            this.label29 = new System.Windows.Forms.Label();
+            this.label30 = new System.Windows.Forms.Label();
+            this.Flow4_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label31 = new System.Windows.Forms.Label();
+            this.Flow4_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label32 = new System.Windows.Forms.Label();
+            this.Rashodomer5_GB = new System.Windows.Forms.GroupBox();
+            this.label33 = new System.Windows.Forms.Label();
+            this.Flow5_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.label34 = new System.Windows.Forms.Label();
+            this.Flow5_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.Flow5_Document_CB = new System.Windows.Forms.ComboBox();
+            this.label35 = new System.Windows.Forms.Label();
+            this.Flow5_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.Flow5_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.label36 = new System.Windows.Forms.Label();
+            this.label37 = new System.Windows.Forms.Label();
+            this.label38 = new System.Windows.Forms.Label();
+            this.Flow5_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label39 = new System.Windows.Forms.Label();
+            this.Flow5_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label40 = new System.Windows.Forms.Label();
+            this.Rashodomer6_GB = new System.Windows.Forms.GroupBox();
+            this.label41 = new System.Windows.Forms.Label();
+            this.Flow6_Diameter_CB = new System.Windows.Forms.ComboBox();
+            this.label42 = new System.Windows.Forms.Label();
+            this.Flow6_GosReestr_CB = new System.Windows.Forms.ComboBox();
+            this.Flow6_Document_CB = new System.Windows.Forms.ComboBox();
+            this.label43 = new System.Windows.Forms.Label();
+            this.Flow6_WeightImpulse_TB = new System.Windows.Forms.TextBox();
+            this.Flow6_Name_SI_CB = new System.Windows.Forms.ComboBox();
+            this.label44 = new System.Windows.Forms.Label();
+            this.label45 = new System.Windows.Forms.Label();
+            this.label46 = new System.Windows.Forms.Label();
+            this.Flow6_Modification_CB = new System.Windows.Forms.ComboBox();
+            this.label47 = new System.Windows.Forms.Label();
+            this.Flow6_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
+            this.label48 = new System.Windows.Forms.Label();
+            this.Next_B = new System.Windows.Forms.Button();
+            this.button1 = new System.Windows.Forms.Button();
+            this.FlowmetersEnable_TB = new System.Windows.Forms.TextBox();
+            this.button2 = new System.Windows.Forms.Button();
+            this.Rashodomer2_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer3_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer6_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer5_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer4_CB = new System.Windows.Forms.CheckBox();
+            this.Rashodomer1_GB.SuspendLayout();
+            this.Rashodomer2_GB.SuspendLayout();
+            this.Rashodomer3_GB.SuspendLayout();
+            this.Rashodomer4_GB.SuspendLayout();
+            this.Rashodomer5_GB.SuspendLayout();
+            this.Rashodomer6_GB.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(20, 229);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(148, 16);
+            this.label7.TabIndex = 33;
+            this.label7.Text = "Документ на поверку";
+            // 
+            // Flow1_Document_CB
+            // 
+            this.Flow1_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_Document_CB.FormattingEnabled = true;
+            this.Flow1_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow1_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow1_Document_CB.Name = "Flow1_Document_CB";
+            this.Flow1_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow1_Document_CB.TabIndex = 32;
+            // 
+            // Flow1_WeightImpulse_TB
+            // 
+            this.Flow1_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow1_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow1_WeightImpulse_TB.Name = "Flow1_WeightImpulse_TB";
+            this.Flow1_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow1_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(20, 199);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(97, 16);
+            this.label6.TabIndex = 30;
+            this.label6.Text = "Вес импульса";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(20, 169);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(157, 16);
+            this.label5.TabIndex = 29;
+            this.label5.Text = "Номинальный диаметр";
+            // 
+            // Flow1_Diameter_CB
+            // 
+            this.Flow1_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_Diameter_CB.FormattingEnabled = true;
+            this.Flow1_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow1_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow1_Diameter_CB.Name = "Flow1_Diameter_CB";
+            this.Flow1_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow1_Diameter_CB.TabIndex = 28;
+            // 
+            // Flow1_ZavodskNomer_TB
+            // 
+            this.Flow1_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow1_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow1_ZavodskNomer_TB.Name = "Flow1_ZavodskNomer_TB";
+            this.Flow1_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow1_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(20, 139);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(122, 16);
+            this.label4.TabIndex = 26;
+            this.label4.Text = "Заводской номер";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(20, 107);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(99, 16);
+            this.label3.TabIndex = 25;
+            this.label3.Text = "Модификация";
+            // 
+            // Flow1_Modification_CB
+            // 
+            this.Flow1_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_Modification_CB.FormattingEnabled = true;
+            this.Flow1_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow1_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow1_Modification_CB.Name = "Flow1_Modification_CB";
+            this.Flow1_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow1_Modification_CB.TabIndex = 24;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(20, 75);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(32, 16);
+            this.label2.TabIndex = 23;
+            this.label2.Text = "Тип";
+            // 
+            // Flow1_Name_SI_CB
+            // 
+            this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_Name_SI_CB.FormattingEnabled = true;
+            this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow1_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow1_Name_SI_CB.Name = "Flow1_Name_SI_CB";
+            this.Flow1_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow1_Name_SI_CB.TabIndex = 22;
+            this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
+            // 
+            // GosReestr
+            // 
+            this.GosReestr.AutoSize = true;
+            this.GosReestr.Location = new System.Drawing.Point(20, 43);
+            this.GosReestr.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.GosReestr.Name = "GosReestr";
+            this.GosReestr.Size = new System.Drawing.Size(111, 16);
+            this.GosReestr.TabIndex = 21;
+            this.GosReestr.Text = "Производитель";
+            // 
+            // Flow1_GosReestr_CB
+            // 
+            this.Flow1_GosReestr_CB.AllowDrop = true;
+            this.Flow1_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_GosReestr_CB.FormattingEnabled = true;
+            this.Flow1_GosReestr_CB.IntegralHeight = false;
+            this.Flow1_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow1_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow1_GosReestr_CB.Name = "Flow1_GosReestr_CB";
+            this.Flow1_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow1_GosReestr_CB.TabIndex = 20;
+            this.Flow1_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.GosReestrCB_SelectedIndexChanged);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label1.Location = new System.Drawing.Point(220, 23);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(899, 39);
+            this.label1.TabIndex = 19;
+            this.label1.Text = "Настройка параметров поверяемых преобразователей";
+            // 
+            // Rashodomer1_GB
+            // 
+            this.Rashodomer1_GB.Controls.Add(this.label8);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_Diameter_CB);
+            this.Rashodomer1_GB.Controls.Add(this.label7);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_GosReestr_CB);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_Document_CB);
+            this.Rashodomer1_GB.Controls.Add(this.GosReestr);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_WeightImpulse_TB);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_Name_SI_CB);
+            this.Rashodomer1_GB.Controls.Add(this.label6);
+            this.Rashodomer1_GB.Controls.Add(this.label2);
+            this.Rashodomer1_GB.Controls.Add(this.label5);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_Modification_CB);
+            this.Rashodomer1_GB.Controls.Add(this.label3);
+            this.Rashodomer1_GB.Controls.Add(this.Flow1_ZavodskNomer_TB);
+            this.Rashodomer1_GB.Controls.Add(this.label4);
+            this.Rashodomer1_GB.Enabled = false;
+            this.Rashodomer1_GB.Location = new System.Drawing.Point(68, 139);
+            this.Rashodomer1_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer1_GB.Name = "Rashodomer1_GB";
+            this.Rashodomer1_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer1_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer1_GB.TabIndex = 34;
+            this.Rashodomer1_GB.TabStop = false;
+            this.Rashodomer1_GB.Tag = "FirstFlowmeter";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label8.Location = new System.Drawing.Point(20, -6);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(195, 29);
+            this.label8.TabIndex = 35;
+            this.label8.Text = "Расходомер №1";
+            // 
+            // Rashodomer1_CB
+            // 
+            this.Rashodomer1_CB.AutoSize = true;
+            this.Rashodomer1_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer1_CB.Location = new System.Drawing.Point(352, 122);
+            this.Rashodomer1_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer1_CB.Name = "Rashodomer1_CB";
+            this.Rashodomer1_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer1_CB.TabIndex = 36;
+            this.Rashodomer1_CB.Text = "Включить";
+            this.Rashodomer1_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer1_CB.CheckedChanged += new System.EventHandler(this.Rashodomer1_CB_CheckedChanged);
+            // 
+            // Rashodomer2_GB
+            // 
+            this.Rashodomer2_GB.Controls.Add(this.label10);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_Diameter_CB);
+            this.Rashodomer2_GB.Controls.Add(this.label11);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_GosReestr_CB);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_Document_CB);
+            this.Rashodomer2_GB.Controls.Add(this.label12);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_WeightImpulse_TB);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_Name_SI_CB);
+            this.Rashodomer2_GB.Controls.Add(this.label13);
+            this.Rashodomer2_GB.Controls.Add(this.label14);
+            this.Rashodomer2_GB.Controls.Add(this.label15);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_Modification_CB);
+            this.Rashodomer2_GB.Controls.Add(this.label16);
+            this.Rashodomer2_GB.Controls.Add(this.Flow2_ZavodskNomer_TB);
+            this.Rashodomer2_GB.Controls.Add(this.label17);
+            this.Rashodomer2_GB.Enabled = false;
+            this.Rashodomer2_GB.Location = new System.Drawing.Point(68, 448);
+            this.Rashodomer2_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer2_GB.Name = "Rashodomer2_GB";
+            this.Rashodomer2_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer2_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer2_GB.TabIndex = 36;
+            this.Rashodomer2_GB.TabStop = false;
+            this.Rashodomer2_GB.Tag = "FirstFlowmeter";
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label10.Location = new System.Drawing.Point(20, -6);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(195, 29);
+            this.label10.TabIndex = 35;
+            this.label10.Text = "Расходомер №2";
+            // 
+            // Flow2_Diameter_CB
+            // 
+            this.Flow2_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_Diameter_CB.FormattingEnabled = true;
+            this.Flow2_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow2_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow2_Diameter_CB.Name = "Flow2_Diameter_CB";
+            this.Flow2_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow2_Diameter_CB.TabIndex = 28;
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(20, 229);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(148, 16);
+            this.label11.TabIndex = 33;
+            this.label11.Text = "Документ на поверку";
+            // 
+            // Flow2_GosReestr_CB
+            // 
+            this.Flow2_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_GosReestr_CB.FormattingEnabled = true;
+            this.Flow2_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow2_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow2_GosReestr_CB.Name = "Flow2_GosReestr_CB";
+            this.Flow2_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow2_GosReestr_CB.TabIndex = 20;
+            this.Flow2_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow2_GosReestr_CB_SelectedIndexChanged);
+            // 
+            // Flow2_Document_CB
+            // 
+            this.Flow2_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_Document_CB.FormattingEnabled = true;
+            this.Flow2_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow2_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow2_Document_CB.Name = "Flow2_Document_CB";
+            this.Flow2_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow2_Document_CB.TabIndex = 32;
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.Location = new System.Drawing.Point(20, 43);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(111, 16);
+            this.label12.TabIndex = 21;
+            this.label12.Text = "Производитель";
+            // 
+            // Flow2_WeightImpulse_TB
+            // 
+            this.Flow2_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow2_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow2_WeightImpulse_TB.Name = "Flow2_WeightImpulse_TB";
+            this.Flow2_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow2_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow2_Name_SI_CB
+            // 
+            this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_Name_SI_CB.FormattingEnabled = true;
+            this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow2_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
+            this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow2_Name_SI_CB.TabIndex = 22;
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Location = new System.Drawing.Point(20, 199);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(97, 16);
+            this.label13.TabIndex = 30;
+            this.label13.Text = "Вес импульса";
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(20, 75);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(32, 16);
+            this.label14.TabIndex = 23;
+            this.label14.Text = "Тип";
+            this.label14.Click += new System.EventHandler(this.label14_Click);
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(20, 169);
+            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(157, 16);
+            this.label15.TabIndex = 29;
+            this.label15.Text = "Номинальный диаметр";
+            // 
+            // Flow2_Modification_CB
+            // 
+            this.Flow2_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_Modification_CB.FormattingEnabled = true;
+            this.Flow2_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow2_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow2_Modification_CB.Name = "Flow2_Modification_CB";
+            this.Flow2_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow2_Modification_CB.TabIndex = 24;
+            // 
+            // label16
+            // 
+            this.label16.AutoSize = true;
+            this.label16.Location = new System.Drawing.Point(20, 107);
+            this.label16.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label16.Name = "label16";
+            this.label16.Size = new System.Drawing.Size(99, 16);
+            this.label16.TabIndex = 25;
+            this.label16.Text = "Модификация";
+            // 
+            // Flow2_ZavodskNomer_TB
+            // 
+            this.Flow2_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow2_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow2_ZavodskNomer_TB.Name = "Flow2_ZavodskNomer_TB";
+            this.Flow2_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow2_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label17
+            // 
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(20, 139);
+            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(122, 16);
+            this.label17.TabIndex = 26;
+            this.label17.Text = "Заводской номер";
+            // 
+            // Rashodomer3_GB
+            // 
+            this.Rashodomer3_GB.Controls.Add(this.label9);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_Diameter_CB);
+            this.Rashodomer3_GB.Controls.Add(this.label18);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_GosReestr_CB);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_Document_CB);
+            this.Rashodomer3_GB.Controls.Add(this.label19);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_WeightImpulse_TB);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_Name_SI_CB);
+            this.Rashodomer3_GB.Controls.Add(this.label20);
+            this.Rashodomer3_GB.Controls.Add(this.label21);
+            this.Rashodomer3_GB.Controls.Add(this.label22);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_Modification_CB);
+            this.Rashodomer3_GB.Controls.Add(this.label23);
+            this.Rashodomer3_GB.Controls.Add(this.Flow3_ZavodskNomer_TB);
+            this.Rashodomer3_GB.Controls.Add(this.label24);
+            this.Rashodomer3_GB.Enabled = false;
+            this.Rashodomer3_GB.Location = new System.Drawing.Point(467, 139);
+            this.Rashodomer3_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer3_GB.Name = "Rashodomer3_GB";
+            this.Rashodomer3_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer3_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer3_GB.TabIndex = 37;
+            this.Rashodomer3_GB.TabStop = false;
+            this.Rashodomer3_GB.Tag = "FirstFlowmeter";
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label9.Location = new System.Drawing.Point(20, -6);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(195, 29);
+            this.label9.TabIndex = 35;
+            this.label9.Text = "Расходомер №3";
+            // 
+            // Flow3_Diameter_CB
+            // 
+            this.Flow3_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_Diameter_CB.FormattingEnabled = true;
+            this.Flow3_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow3_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow3_Diameter_CB.Name = "Flow3_Diameter_CB";
+            this.Flow3_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow3_Diameter_CB.TabIndex = 28;
+            // 
+            // label18
+            // 
+            this.label18.AutoSize = true;
+            this.label18.Location = new System.Drawing.Point(20, 229);
+            this.label18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label18.Name = "label18";
+            this.label18.Size = new System.Drawing.Size(148, 16);
+            this.label18.TabIndex = 33;
+            this.label18.Text = "Документ на поверку";
+            // 
+            // Flow3_GosReestr_CB
+            // 
+            this.Flow3_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_GosReestr_CB.FormattingEnabled = true;
+            this.Flow3_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow3_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow3_GosReestr_CB.Name = "Flow3_GosReestr_CB";
+            this.Flow3_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow3_GosReestr_CB.TabIndex = 20;
+            this.Flow3_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow3_GosReestr_CB_SelectedIndexChanged);
+            // 
+            // Flow3_Document_CB
+            // 
+            this.Flow3_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_Document_CB.FormattingEnabled = true;
+            this.Flow3_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow3_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow3_Document_CB.Name = "Flow3_Document_CB";
+            this.Flow3_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow3_Document_CB.TabIndex = 32;
+            // 
+            // label19
+            // 
+            this.label19.AutoSize = true;
+            this.label19.Location = new System.Drawing.Point(20, 43);
+            this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label19.Name = "label19";
+            this.label19.Size = new System.Drawing.Size(111, 16);
+            this.label19.TabIndex = 21;
+            this.label19.Text = "Производитель";
+            // 
+            // Flow3_WeightImpulse_TB
+            // 
+            this.Flow3_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow3_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow3_WeightImpulse_TB.Name = "Flow3_WeightImpulse_TB";
+            this.Flow3_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow3_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow3_Name_SI_CB
+            // 
+            this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_Name_SI_CB.FormattingEnabled = true;
+            this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow3_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
+            this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow3_Name_SI_CB.TabIndex = 22;
+            // 
+            // label20
+            // 
+            this.label20.AutoSize = true;
+            this.label20.Location = new System.Drawing.Point(20, 199);
+            this.label20.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label20.Name = "label20";
+            this.label20.Size = new System.Drawing.Size(97, 16);
+            this.label20.TabIndex = 30;
+            this.label20.Text = "Вес импульса";
+            // 
+            // label21
+            // 
+            this.label21.AutoSize = true;
+            this.label21.Location = new System.Drawing.Point(20, 75);
+            this.label21.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label21.Name = "label21";
+            this.label21.Size = new System.Drawing.Size(32, 16);
+            this.label21.TabIndex = 23;
+            this.label21.Text = "Тип";
+            // 
+            // label22
+            // 
+            this.label22.AutoSize = true;
+            this.label22.Location = new System.Drawing.Point(20, 169);
+            this.label22.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label22.Name = "label22";
+            this.label22.Size = new System.Drawing.Size(157, 16);
+            this.label22.TabIndex = 29;
+            this.label22.Text = "Номинальный диаметр";
+            // 
+            // Flow3_Modification_CB
+            // 
+            this.Flow3_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_Modification_CB.FormattingEnabled = true;
+            this.Flow3_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow3_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow3_Modification_CB.Name = "Flow3_Modification_CB";
+            this.Flow3_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow3_Modification_CB.TabIndex = 24;
+            // 
+            // label23
+            // 
+            this.label23.AutoSize = true;
+            this.label23.Location = new System.Drawing.Point(20, 107);
+            this.label23.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label23.Name = "label23";
+            this.label23.Size = new System.Drawing.Size(99, 16);
+            this.label23.TabIndex = 25;
+            this.label23.Text = "Модификация";
+            // 
+            // Flow3_ZavodskNomer_TB
+            // 
+            this.Flow3_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow3_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow3_ZavodskNomer_TB.Name = "Flow3_ZavodskNomer_TB";
+            this.Flow3_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow3_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label24
+            // 
+            this.label24.AutoSize = true;
+            this.label24.Location = new System.Drawing.Point(20, 139);
+            this.label24.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label24.Name = "label24";
+            this.label24.Size = new System.Drawing.Size(122, 16);
+            this.label24.TabIndex = 26;
+            this.label24.Text = "Заводской номер";
+            // 
+            // Rashodomer4_GB
+            // 
+            this.Rashodomer4_GB.Controls.Add(this.label25);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_Diameter_CB);
+            this.Rashodomer4_GB.Controls.Add(this.label26);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_GosReestr_CB);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_Document_CB);
+            this.Rashodomer4_GB.Controls.Add(this.label27);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_WeightImpulse_TB);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_Name_SI_CB);
+            this.Rashodomer4_GB.Controls.Add(this.label28);
+            this.Rashodomer4_GB.Controls.Add(this.label29);
+            this.Rashodomer4_GB.Controls.Add(this.label30);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_Modification_CB);
+            this.Rashodomer4_GB.Controls.Add(this.label31);
+            this.Rashodomer4_GB.Controls.Add(this.Flow4_ZavodskNomer_TB);
+            this.Rashodomer4_GB.Controls.Add(this.label32);
+            this.Rashodomer4_GB.Enabled = false;
+            this.Rashodomer4_GB.Location = new System.Drawing.Point(467, 448);
+            this.Rashodomer4_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer4_GB.Name = "Rashodomer4_GB";
+            this.Rashodomer4_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer4_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer4_GB.TabIndex = 38;
+            this.Rashodomer4_GB.TabStop = false;
+            this.Rashodomer4_GB.Tag = "FirstFlowmeter";
+            // 
+            // label25
+            // 
+            this.label25.AutoSize = true;
+            this.label25.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label25.Location = new System.Drawing.Point(20, -6);
+            this.label25.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label25.Name = "label25";
+            this.label25.Size = new System.Drawing.Size(195, 29);
+            this.label25.TabIndex = 35;
+            this.label25.Text = "Расходомер №4";
+            // 
+            // Flow4_Diameter_CB
+            // 
+            this.Flow4_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_Diameter_CB.FormattingEnabled = true;
+            this.Flow4_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow4_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow4_Diameter_CB.Name = "Flow4_Diameter_CB";
+            this.Flow4_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow4_Diameter_CB.TabIndex = 28;
+            // 
+            // label26
+            // 
+            this.label26.AutoSize = true;
+            this.label26.Location = new System.Drawing.Point(20, 229);
+            this.label26.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label26.Name = "label26";
+            this.label26.Size = new System.Drawing.Size(148, 16);
+            this.label26.TabIndex = 33;
+            this.label26.Text = "Документ на поверку";
+            // 
+            // Flow4_GosReestr_CB
+            // 
+            this.Flow4_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_GosReestr_CB.FormattingEnabled = true;
+            this.Flow4_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow4_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow4_GosReestr_CB.Name = "Flow4_GosReestr_CB";
+            this.Flow4_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow4_GosReestr_CB.TabIndex = 20;
+            this.Flow4_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow4_GosReestr_CB_SelectedIndexChanged);
+            // 
+            // Flow4_Document_CB
+            // 
+            this.Flow4_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_Document_CB.FormattingEnabled = true;
+            this.Flow4_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow4_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow4_Document_CB.Name = "Flow4_Document_CB";
+            this.Flow4_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow4_Document_CB.TabIndex = 32;
+            // 
+            // label27
+            // 
+            this.label27.AutoSize = true;
+            this.label27.Location = new System.Drawing.Point(20, 43);
+            this.label27.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label27.Name = "label27";
+            this.label27.Size = new System.Drawing.Size(111, 16);
+            this.label27.TabIndex = 21;
+            this.label27.Text = "Производитель";
+            // 
+            // Flow4_WeightImpulse_TB
+            // 
+            this.Flow4_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow4_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow4_WeightImpulse_TB.Name = "Flow4_WeightImpulse_TB";
+            this.Flow4_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow4_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow4_Name_SI_CB
+            // 
+            this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_Name_SI_CB.FormattingEnabled = true;
+            this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow4_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
+            this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow4_Name_SI_CB.TabIndex = 22;
+            // 
+            // label28
+            // 
+            this.label28.AutoSize = true;
+            this.label28.Location = new System.Drawing.Point(20, 199);
+            this.label28.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label28.Name = "label28";
+            this.label28.Size = new System.Drawing.Size(97, 16);
+            this.label28.TabIndex = 30;
+            this.label28.Text = "Вес импульса";
+            // 
+            // label29
+            // 
+            this.label29.AutoSize = true;
+            this.label29.Location = new System.Drawing.Point(20, 75);
+            this.label29.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label29.Name = "label29";
+            this.label29.Size = new System.Drawing.Size(136, 16);
+            this.label29.TabIndex = 23;
+            this.label29.Text = "Наиименование СИ";
+            // 
+            // label30
+            // 
+            this.label30.AutoSize = true;
+            this.label30.Location = new System.Drawing.Point(20, 169);
+            this.label30.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label30.Name = "label30";
+            this.label30.Size = new System.Drawing.Size(157, 16);
+            this.label30.TabIndex = 29;
+            this.label30.Text = "Номинальный диаметр";
+            // 
+            // Flow4_Modification_CB
+            // 
+            this.Flow4_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_Modification_CB.FormattingEnabled = true;
+            this.Flow4_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow4_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow4_Modification_CB.Name = "Flow4_Modification_CB";
+            this.Flow4_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow4_Modification_CB.TabIndex = 24;
+            // 
+            // label31
+            // 
+            this.label31.AutoSize = true;
+            this.label31.Location = new System.Drawing.Point(20, 107);
+            this.label31.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label31.Name = "label31";
+            this.label31.Size = new System.Drawing.Size(99, 16);
+            this.label31.TabIndex = 25;
+            this.label31.Text = "Модификация";
+            // 
+            // Flow4_ZavodskNomer_TB
+            // 
+            this.Flow4_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow4_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow4_ZavodskNomer_TB.Name = "Flow4_ZavodskNomer_TB";
+            this.Flow4_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow4_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label32
+            // 
+            this.label32.AutoSize = true;
+            this.label32.Location = new System.Drawing.Point(20, 139);
+            this.label32.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label32.Name = "label32";
+            this.label32.Size = new System.Drawing.Size(122, 16);
+            this.label32.TabIndex = 26;
+            this.label32.Text = "Заводской номер";
+            // 
+            // Rashodomer5_GB
+            // 
+            this.Rashodomer5_GB.Controls.Add(this.label33);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_Diameter_CB);
+            this.Rashodomer5_GB.Controls.Add(this.label34);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_GosReestr_CB);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_Document_CB);
+            this.Rashodomer5_GB.Controls.Add(this.label35);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_WeightImpulse_TB);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_Name_SI_CB);
+            this.Rashodomer5_GB.Controls.Add(this.label36);
+            this.Rashodomer5_GB.Controls.Add(this.label37);
+            this.Rashodomer5_GB.Controls.Add(this.label38);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_Modification_CB);
+            this.Rashodomer5_GB.Controls.Add(this.label39);
+            this.Rashodomer5_GB.Controls.Add(this.Flow5_ZavodskNomer_TB);
+            this.Rashodomer5_GB.Controls.Add(this.label40);
+            this.Rashodomer5_GB.Enabled = false;
+            this.Rashodomer5_GB.Location = new System.Drawing.Point(865, 139);
+            this.Rashodomer5_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer5_GB.Name = "Rashodomer5_GB";
+            this.Rashodomer5_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer5_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer5_GB.TabIndex = 37;
+            this.Rashodomer5_GB.TabStop = false;
+            this.Rashodomer5_GB.Tag = "FirstFlowmeter";
+            // 
+            // label33
+            // 
+            this.label33.AutoSize = true;
+            this.label33.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label33.Location = new System.Drawing.Point(20, -6);
+            this.label33.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label33.Name = "label33";
+            this.label33.Size = new System.Drawing.Size(195, 29);
+            this.label33.TabIndex = 35;
+            this.label33.Text = "Расходомер №5";
+            // 
+            // Flow5_Diameter_CB
+            // 
+            this.Flow5_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_Diameter_CB.FormattingEnabled = true;
+            this.Flow5_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow5_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow5_Diameter_CB.Name = "Flow5_Diameter_CB";
+            this.Flow5_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow5_Diameter_CB.TabIndex = 28;
+            // 
+            // label34
+            // 
+            this.label34.AutoSize = true;
+            this.label34.Location = new System.Drawing.Point(20, 229);
+            this.label34.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label34.Name = "label34";
+            this.label34.Size = new System.Drawing.Size(148, 16);
+            this.label34.TabIndex = 33;
+            this.label34.Text = "Документ на поверку";
+            // 
+            // Flow5_GosReestr_CB
+            // 
+            this.Flow5_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_GosReestr_CB.FormattingEnabled = true;
+            this.Flow5_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow5_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow5_GosReestr_CB.Name = "Flow5_GosReestr_CB";
+            this.Flow5_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow5_GosReestr_CB.TabIndex = 20;
+            this.Flow5_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow5_GosReestr_CB_SelectedIndexChanged);
+            // 
+            // Flow5_Document_CB
+            // 
+            this.Flow5_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_Document_CB.FormattingEnabled = true;
+            this.Flow5_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow5_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow5_Document_CB.Name = "Flow5_Document_CB";
+            this.Flow5_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow5_Document_CB.TabIndex = 32;
+            // 
+            // label35
+            // 
+            this.label35.AutoSize = true;
+            this.label35.Location = new System.Drawing.Point(20, 43);
+            this.label35.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label35.Name = "label35";
+            this.label35.Size = new System.Drawing.Size(111, 16);
+            this.label35.TabIndex = 21;
+            this.label35.Text = "Производитель";
+            // 
+            // Flow5_WeightImpulse_TB
+            // 
+            this.Flow5_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow5_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow5_WeightImpulse_TB.Name = "Flow5_WeightImpulse_TB";
+            this.Flow5_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow5_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow5_Name_SI_CB
+            // 
+            this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_Name_SI_CB.FormattingEnabled = true;
+            this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow5_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
+            this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow5_Name_SI_CB.TabIndex = 22;
+            // 
+            // label36
+            // 
+            this.label36.AutoSize = true;
+            this.label36.Location = new System.Drawing.Point(20, 199);
+            this.label36.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label36.Name = "label36";
+            this.label36.Size = new System.Drawing.Size(97, 16);
+            this.label36.TabIndex = 30;
+            this.label36.Text = "Вес импульса";
+            // 
+            // label37
+            // 
+            this.label37.AutoSize = true;
+            this.label37.Location = new System.Drawing.Point(20, 75);
+            this.label37.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label37.Name = "label37";
+            this.label37.Size = new System.Drawing.Size(32, 16);
+            this.label37.TabIndex = 23;
+            this.label37.Text = "Тип";
+            // 
+            // label38
+            // 
+            this.label38.AutoSize = true;
+            this.label38.Location = new System.Drawing.Point(20, 169);
+            this.label38.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label38.Name = "label38";
+            this.label38.Size = new System.Drawing.Size(157, 16);
+            this.label38.TabIndex = 29;
+            this.label38.Text = "Номинальный диаметр";
+            // 
+            // Flow5_Modification_CB
+            // 
+            this.Flow5_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_Modification_CB.FormattingEnabled = true;
+            this.Flow5_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow5_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow5_Modification_CB.Name = "Flow5_Modification_CB";
+            this.Flow5_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow5_Modification_CB.TabIndex = 24;
+            // 
+            // label39
+            // 
+            this.label39.AutoSize = true;
+            this.label39.Location = new System.Drawing.Point(20, 107);
+            this.label39.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label39.Name = "label39";
+            this.label39.Size = new System.Drawing.Size(99, 16);
+            this.label39.TabIndex = 25;
+            this.label39.Text = "Модификация";
+            // 
+            // Flow5_ZavodskNomer_TB
+            // 
+            this.Flow5_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow5_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow5_ZavodskNomer_TB.Name = "Flow5_ZavodskNomer_TB";
+            this.Flow5_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow5_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label40
+            // 
+            this.label40.AutoSize = true;
+            this.label40.Location = new System.Drawing.Point(20, 139);
+            this.label40.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label40.Name = "label40";
+            this.label40.Size = new System.Drawing.Size(122, 16);
+            this.label40.TabIndex = 26;
+            this.label40.Text = "Заводской номер";
+            // 
+            // Rashodomer6_GB
+            // 
+            this.Rashodomer6_GB.Controls.Add(this.label41);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_Diameter_CB);
+            this.Rashodomer6_GB.Controls.Add(this.label42);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_GosReestr_CB);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_Document_CB);
+            this.Rashodomer6_GB.Controls.Add(this.label43);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_WeightImpulse_TB);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_Name_SI_CB);
+            this.Rashodomer6_GB.Controls.Add(this.label44);
+            this.Rashodomer6_GB.Controls.Add(this.label45);
+            this.Rashodomer6_GB.Controls.Add(this.label46);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_Modification_CB);
+            this.Rashodomer6_GB.Controls.Add(this.label47);
+            this.Rashodomer6_GB.Controls.Add(this.Flow6_ZavodskNomer_TB);
+            this.Rashodomer6_GB.Controls.Add(this.label48);
+            this.Rashodomer6_GB.Enabled = false;
+            this.Rashodomer6_GB.Location = new System.Drawing.Point(865, 448);
+            this.Rashodomer6_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer6_GB.Name = "Rashodomer6_GB";
+            this.Rashodomer6_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer6_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer6_GB.TabIndex = 37;
+            this.Rashodomer6_GB.TabStop = false;
+            this.Rashodomer6_GB.Tag = "FirstFlowmeter";
+            this.Rashodomer6_GB.Enter += new System.EventHandler(this.groupBox6_Enter);
+            // 
+            // label41
+            // 
+            this.label41.AutoSize = true;
+            this.label41.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label41.Location = new System.Drawing.Point(20, -6);
+            this.label41.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label41.Name = "label41";
+            this.label41.Size = new System.Drawing.Size(195, 29);
+            this.label41.TabIndex = 35;
+            this.label41.Text = "Расходомер №6";
+            // 
+            // Flow6_Diameter_CB
+            // 
+            this.Flow6_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_Diameter_CB.FormattingEnabled = true;
+            this.Flow6_Diameter_CB.Location = new System.Drawing.Point(192, 162);
+            this.Flow6_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow6_Diameter_CB.Name = "Flow6_Diameter_CB";
+            this.Flow6_Diameter_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow6_Diameter_CB.TabIndex = 28;
+            // 
+            // label42
+            // 
+            this.label42.AutoSize = true;
+            this.label42.Location = new System.Drawing.Point(20, 229);
+            this.label42.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label42.Name = "label42";
+            this.label42.Size = new System.Drawing.Size(148, 16);
+            this.label42.TabIndex = 33;
+            this.label42.Text = "Документ на поверку";
+            // 
+            // Flow6_GosReestr_CB
+            // 
+            this.Flow6_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_GosReestr_CB.FormattingEnabled = true;
+            this.Flow6_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow6_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow6_GosReestr_CB.Name = "Flow6_GosReestr_CB";
+            this.Flow6_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow6_GosReestr_CB.TabIndex = 20;
+            this.Flow6_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow6_GosReestr_CB_SelectedIndexChanged);
+            // 
+            // Flow6_Document_CB
+            // 
+            this.Flow6_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_Document_CB.FormattingEnabled = true;
+            this.Flow6_Document_CB.Location = new System.Drawing.Point(192, 223);
+            this.Flow6_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow6_Document_CB.Name = "Flow6_Document_CB";
+            this.Flow6_Document_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow6_Document_CB.TabIndex = 32;
+            // 
+            // label43
+            // 
+            this.label43.AutoSize = true;
+            this.label43.Location = new System.Drawing.Point(20, 43);
+            this.label43.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label43.Name = "label43";
+            this.label43.Size = new System.Drawing.Size(111, 16);
+            this.label43.TabIndex = 21;
+            this.label43.Text = "Производитель";
+            // 
+            // Flow6_WeightImpulse_TB
+            // 
+            this.Flow6_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
+            this.Flow6_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow6_WeightImpulse_TB.Name = "Flow6_WeightImpulse_TB";
+            this.Flow6_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow6_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow6_Name_SI_CB
+            // 
+            this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_Name_SI_CB.FormattingEnabled = true;
+            this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow6_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
+            this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow6_Name_SI_CB.TabIndex = 22;
+            // 
+            // label44
+            // 
+            this.label44.AutoSize = true;
+            this.label44.Location = new System.Drawing.Point(20, 199);
+            this.label44.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label44.Name = "label44";
+            this.label44.Size = new System.Drawing.Size(97, 16);
+            this.label44.TabIndex = 30;
+            this.label44.Text = "Вес импульса";
+            // 
+            // label45
+            // 
+            this.label45.AutoSize = true;
+            this.label45.Location = new System.Drawing.Point(20, 75);
+            this.label45.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label45.Name = "label45";
+            this.label45.Size = new System.Drawing.Size(32, 16);
+            this.label45.TabIndex = 23;
+            this.label45.Text = "Тип";
+            // 
+            // label46
+            // 
+            this.label46.AutoSize = true;
+            this.label46.Location = new System.Drawing.Point(20, 169);
+            this.label46.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label46.Name = "label46";
+            this.label46.Size = new System.Drawing.Size(157, 16);
+            this.label46.TabIndex = 29;
+            this.label46.Text = "Номинальный диаметр";
+            // 
+            // Flow6_Modification_CB
+            // 
+            this.Flow6_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_Modification_CB.FormattingEnabled = true;
+            this.Flow6_Modification_CB.Location = new System.Drawing.Point(192, 102);
+            this.Flow6_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Flow6_Modification_CB.Name = "Flow6_Modification_CB";
+            this.Flow6_Modification_CB.Size = new System.Drawing.Size(177, 24);
+            this.Flow6_Modification_CB.TabIndex = 24;
+            // 
+            // label47
+            // 
+            this.label47.AutoSize = true;
+            this.label47.Location = new System.Drawing.Point(20, 107);
+            this.label47.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label47.Name = "label47";
+            this.label47.Size = new System.Drawing.Size(99, 16);
+            this.label47.TabIndex = 25;
+            this.label47.Text = "Модификация";
+            // 
+            // Flow6_ZavodskNomer_TB
+            // 
+            this.Flow6_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
+            this.Flow6_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Flow6_ZavodskNomer_TB.Name = "Flow6_ZavodskNomer_TB";
+            this.Flow6_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
+            this.Flow6_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label48
+            // 
+            this.label48.AutoSize = true;
+            this.label48.Location = new System.Drawing.Point(20, 139);
+            this.label48.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label48.Name = "label48";
+            this.label48.Size = new System.Drawing.Size(122, 16);
+            this.label48.TabIndex = 26;
+            this.label48.Text = "Заводской номер";
+            // 
+            // Next_B
+            // 
+            this.Next_B.Location = new System.Drawing.Point(1156, 727);
+            this.Next_B.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Next_B.Name = "Next_B";
+            this.Next_B.Size = new System.Drawing.Size(100, 28);
+            this.Next_B.TabIndex = 42;
+            this.Next_B.Text = "Далее";
+            this.Next_B.UseVisualStyleBackColor = true;
+            this.Next_B.Click += new System.EventHandler(this.Next_B_Click);
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(68, 727);
+            this.button1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(100, 28);
+            this.button1.TabIndex = 43;
+            this.button1.Text = "Выход";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // FlowmetersEnable_TB
+            // 
+            this.FlowmetersEnable_TB.Location = new System.Drawing.Point(1074, 92);
+            this.FlowmetersEnable_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.FlowmetersEnable_TB.Name = "FlowmetersEnable_TB";
+            this.FlowmetersEnable_TB.Size = new System.Drawing.Size(177, 22);
+            this.FlowmetersEnable_TB.TabIndex = 36;
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(971, 89);
+            this.button2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(100, 28);
+            this.button2.TabIndex = 44;
+            this.button2.Text = "Тест";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // Rashodomer2_CB
+            // 
+            this.Rashodomer2_CB.AutoSize = true;
+            this.Rashodomer2_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer2_CB.Location = new System.Drawing.Point(353, 432);
+            this.Rashodomer2_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer2_CB.Name = "Rashodomer2_CB";
+            this.Rashodomer2_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer2_CB.TabIndex = 45;
+            this.Rashodomer2_CB.Text = "Включить";
+            this.Rashodomer2_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer2_CB.CheckedChanged += new System.EventHandler(this.Rashodomer2_CB_CheckedChanged);
+            // 
+            // Rashodomer3_CB
+            // 
+            this.Rashodomer3_CB.AutoSize = true;
+            this.Rashodomer3_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer3_CB.Location = new System.Drawing.Point(751, 123);
+            this.Rashodomer3_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer3_CB.Name = "Rashodomer3_CB";
+            this.Rashodomer3_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer3_CB.TabIndex = 46;
+            this.Rashodomer3_CB.Text = "Включить";
+            this.Rashodomer3_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer3_CB.CheckedChanged += new System.EventHandler(this.Rashodomer3_CB_CheckedChanged);
+            // 
+            // Rashodomer6_CB
+            // 
+            this.Rashodomer6_CB.AutoSize = true;
+            this.Rashodomer6_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer6_CB.Location = new System.Drawing.Point(1149, 433);
+            this.Rashodomer6_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer6_CB.Name = "Rashodomer6_CB";
+            this.Rashodomer6_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer6_CB.TabIndex = 49;
+            this.Rashodomer6_CB.Text = "Включить";
+            this.Rashodomer6_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer6_CB.CheckedChanged += new System.EventHandler(this.Rashodomer6_CB_CheckedChanged);
+            // 
+            // Rashodomer5_CB
+            // 
+            this.Rashodomer5_CB.AutoSize = true;
+            this.Rashodomer5_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer5_CB.Location = new System.Drawing.Point(1151, 124);
+            this.Rashodomer5_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer5_CB.Name = "Rashodomer5_CB";
+            this.Rashodomer5_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer5_CB.TabIndex = 48;
+            this.Rashodomer5_CB.Text = "Включить";
+            this.Rashodomer5_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer5_CB.CheckedChanged += new System.EventHandler(this.Rashodomer5_CB_CheckedChanged);
+            // 
+            // Rashodomer4_CB
+            // 
+            this.Rashodomer4_CB.AutoSize = true;
+            this.Rashodomer4_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.Rashodomer4_CB.Location = new System.Drawing.Point(751, 432);
+            this.Rashodomer4_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rashodomer4_CB.Name = "Rashodomer4_CB";
+            this.Rashodomer4_CB.Size = new System.Drawing.Size(102, 21);
+            this.Rashodomer4_CB.TabIndex = 47;
+            this.Rashodomer4_CB.Text = "Включить";
+            this.Rashodomer4_CB.UseVisualStyleBackColor = true;
+            this.Rashodomer4_CB.CheckedChanged += new System.EventHandler(this.Rashodomer4_CB_CheckedChanged);
+            // 
+            // MetersSetupForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1323, 777);
+            this.Controls.Add(this.Rashodomer6_CB);
+            this.Controls.Add(this.Rashodomer5_CB);
+            this.Controls.Add(this.Rashodomer4_CB);
+            this.Controls.Add(this.Rashodomer3_CB);
+            this.Controls.Add(this.Rashodomer2_CB);
+            this.Controls.Add(this.Rashodomer1_CB);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.FlowmetersEnable_TB);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.Next_B);
+            this.Controls.Add(this.Rashodomer6_GB);
+            this.Controls.Add(this.Rashodomer5_GB);
+            this.Controls.Add(this.Rashodomer4_GB);
+            this.Controls.Add(this.Rashodomer3_GB);
+            this.Controls.Add(this.Rashodomer2_GB);
+            this.Controls.Add(this.Rashodomer1_GB);
+            this.Controls.Add(this.label1);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Name = "MetersSetupForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Настройка параметров поверяемых преобразователей";
+            this.Load += new System.EventHandler(this.MetersSetupForm_Load);
+            this.Rashodomer1_GB.ResumeLayout(false);
+            this.Rashodomer1_GB.PerformLayout();
+            this.Rashodomer2_GB.ResumeLayout(false);
+            this.Rashodomer2_GB.PerformLayout();
+            this.Rashodomer3_GB.ResumeLayout(false);
+            this.Rashodomer3_GB.PerformLayout();
+            this.Rashodomer4_GB.ResumeLayout(false);
+            this.Rashodomer4_GB.PerformLayout();
+            this.Rashodomer5_GB.ResumeLayout(false);
+            this.Rashodomer5_GB.PerformLayout();
+            this.Rashodomer6_GB.ResumeLayout(false);
+            this.Rashodomer6_GB.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.ComponentModel.BackgroundWorker backgroundWorker1;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.ComboBox Flow1_Document_CB;
+        private System.Windows.Forms.TextBox Flow1_WeightImpulse_TB;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.ComboBox Flow1_Diameter_CB;
+        private System.Windows.Forms.TextBox Flow1_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.ComboBox Flow1_Modification_CB;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox Flow1_Name_SI_CB;
+        private System.Windows.Forms.Label GosReestr;
+        private System.Windows.Forms.ComboBox Flow1_GosReestr_CB;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.GroupBox Rashodomer1_GB;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.GroupBox Rashodomer2_GB;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.ComboBox Flow2_Diameter_CB;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.ComboBox Flow2_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow2_Document_CB;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.TextBox Flow2_WeightImpulse_TB;
+        private System.Windows.Forms.ComboBox Flow2_Name_SI_CB;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.ComboBox Flow2_Modification_CB;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.TextBox Flow2_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.GroupBox Rashodomer3_GB;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.ComboBox Flow3_Diameter_CB;
+        private System.Windows.Forms.Label label18;
+        private System.Windows.Forms.ComboBox Flow3_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow3_Document_CB;
+        private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.TextBox Flow3_WeightImpulse_TB;
+        private System.Windows.Forms.ComboBox Flow3_Name_SI_CB;
+        private System.Windows.Forms.Label label20;
+        private System.Windows.Forms.Label label21;
+        private System.Windows.Forms.Label label22;
+        private System.Windows.Forms.ComboBox Flow3_Modification_CB;
+        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.TextBox Flow3_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label24;
+        private System.Windows.Forms.GroupBox Rashodomer4_GB;
+        private System.Windows.Forms.Label label25;
+        private System.Windows.Forms.ComboBox Flow4_Diameter_CB;
+        private System.Windows.Forms.Label label26;
+        private System.Windows.Forms.ComboBox Flow4_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow4_Document_CB;
+        private System.Windows.Forms.Label label27;
+        private System.Windows.Forms.TextBox Flow4_WeightImpulse_TB;
+        private System.Windows.Forms.ComboBox Flow4_Name_SI_CB;
+        private System.Windows.Forms.Label label28;
+        private System.Windows.Forms.Label label29;
+        private System.Windows.Forms.Label label30;
+        private System.Windows.Forms.ComboBox Flow4_Modification_CB;
+        private System.Windows.Forms.Label label31;
+        private System.Windows.Forms.TextBox Flow4_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label32;
+        private System.Windows.Forms.GroupBox Rashodomer5_GB;
+        private System.Windows.Forms.Label label33;
+        private System.Windows.Forms.ComboBox Flow5_Diameter_CB;
+        private System.Windows.Forms.Label label34;
+        private System.Windows.Forms.ComboBox Flow5_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow5_Document_CB;
+        private System.Windows.Forms.Label label35;
+        private System.Windows.Forms.TextBox Flow5_WeightImpulse_TB;
+        private System.Windows.Forms.ComboBox Flow5_Name_SI_CB;
+        private System.Windows.Forms.Label label36;
+        private System.Windows.Forms.Label label37;
+        private System.Windows.Forms.Label label38;
+        private System.Windows.Forms.ComboBox Flow5_Modification_CB;
+        private System.Windows.Forms.Label label39;
+        private System.Windows.Forms.TextBox Flow5_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label40;
+        private System.Windows.Forms.GroupBox Rashodomer6_GB;
+        private System.Windows.Forms.Label label41;
+        private System.Windows.Forms.ComboBox Flow6_Diameter_CB;
+        private System.Windows.Forms.Label label42;
+        private System.Windows.Forms.ComboBox Flow6_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow6_Document_CB;
+        private System.Windows.Forms.Label label43;
+        private System.Windows.Forms.TextBox Flow6_WeightImpulse_TB;
+        private System.Windows.Forms.ComboBox Flow6_Name_SI_CB;
+        private System.Windows.Forms.Label label44;
+        private System.Windows.Forms.Label label45;
+        private System.Windows.Forms.Label label46;
+        private System.Windows.Forms.ComboBox Flow6_Modification_CB;
+        private System.Windows.Forms.Label label47;
+        private System.Windows.Forms.TextBox Flow6_ZavodskNomer_TB;
+        private System.Windows.Forms.Label label48;
+        private System.Windows.Forms.Button Next_B;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.TextBox FlowmetersEnable_TB;
+        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.CheckBox Rashodomer1_CB;
+        private System.Windows.Forms.CheckBox Rashodomer2_CB;
+        private System.Windows.Forms.CheckBox Rashodomer3_CB;
+        private System.Windows.Forms.CheckBox Rashodomer6_CB;
+        private System.Windows.Forms.CheckBox Rashodomer5_CB;
+        private System.Windows.Forms.CheckBox Rashodomer4_CB;
+    }
+}

--- a/Forms/MetersSetupForm.cs
+++ b/Forms/MetersSetupForm.cs
@@ -1,109 +1,36 @@
 using System;
-using System.Drawing;
 using System.Windows.Forms;
 
 namespace PoverkaWinForms
 {
-    public class MetersSetupForm : Form
+    public partial class MetersSetupForm : Form
     {
         public MetersSetupForm()
         {
             InitializeComponent();
         }
 
-        private void InitializeComponent()
+        private void MetersSetupForm_Load(object sender, EventArgs e)
         {
-            Text = "Настройка параметров поверяемых преобразователей";
-            StartPosition = FormStartPosition.CenterScreen;
-            ClientSize = new Size(980, 600);
-
-            var lblTitle = new Label
-            {
-                Text = "Настройка параметров поверяемых преобразователей",
-                Dock = DockStyle.Top,
-                Height = 40,
-                TextAlign = ContentAlignment.MiddleCenter,
-                Font = new Font(Font.FontFamily, 12, FontStyle.Bold)
-            };
-            Controls.Add(lblTitle);
-
-            var btnTest = new Button
-            {
-                Text = "Тест",
-                Size = new Size(75, 30),
-                Location = new Point(ClientSize.Width - 85, 45),
-                Anchor = AnchorStyles.Top | AnchorStyles.Right
-            };
-            Controls.Add(btnTest);
-
-            string[] labels = { "Производитель", "Тип", "Заводской номер", "Заводской номер СИ", "Заводской номер рс", "Документ на поверку" };
-            int groupWidth = 300;
-            int groupHeight = 200;
-            int margin = 10;
-            for (int i = 0; i < 6; i++)
-            {
-                var grp = new GroupBox
-                {
-                    Text = $"Расходомер №{i + 1}",
-                    Size = new Size(groupWidth, groupHeight)
-                };
-                int row = i / 3;
-                int col = i % 3;
-                grp.Location = new Point(margin + (groupWidth + margin) * col,
-                    80 + (groupHeight + margin) * row);
-
-                var chk = new CheckBox
-                {
-                    Text = "Включить",
-                    AutoSize = true,
-                    Location = new Point(grp.Width - 80, 0)
-                };
-                grp.Controls.Add(chk);
-
-                for (int l = 0; l < labels.Length; l++)
-                {
-                    var lbl = new Label
-                    {
-                        Text = labels[l],
-                        Location = new Point(10, 25 + l * 28),
-                        AutoSize = true
-                    };
-                    var txt = new TextBox
-                    {
-                        Location = new Point(150, 22 + l * 28),
-                        Width = 130
-                    };
-                    grp.Controls.Add(lbl);
-                    grp.Controls.Add(txt);
-                }
-
-                Controls.Add(grp);
-            }
-
-            var btnInput = new Button
-            {
-                Text = "Ввод",
-                Size = new Size(75, 30),
-                Location = new Point(margin, ClientSize.Height - 40),
-                Anchor = AnchorStyles.Bottom | AnchorStyles.Left
-            };
-            Controls.Add(btnInput);
-
-            var btnExit = new Button
-            {
-                Text = "Выход",
-                Size = new Size(75, 30),
-                Location = new Point(ClientSize.Width - 85, ClientSize.Height - 40),
-                Anchor = AnchorStyles.Bottom | AnchorStyles.Right
-            };
-            btnExit.Click += BtnExit_Click;
-            Controls.Add(btnExit);
+            // TODO: добавить логику загрузки при необходимости
         }
 
-        private void BtnExit_Click(object sender, EventArgs e)
-        {
-            Close();
-        }
+        private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow4_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow5_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void label14_Click(object sender, EventArgs e) { }
+        private void Next_B_Click(object sender, EventArgs e) { }
+        private void button1_Click(object sender, EventArgs e) { }
+        private void button2_Click(object sender, EventArgs e) { }
+        private void Rashodomer1_CB_CheckedChanged(object sender, EventArgs e) { }
+        private void Rashodomer2_CB_CheckedChanged(object sender, EventArgs e) { }
+        private void Rashodomer3_CB_CheckedChanged(object sender, EventArgs e) { }
+        private void Rashodomer6_CB_CheckedChanged(object sender, EventArgs e) { }
+        private void Rashodomer5_CB_CheckedChanged(object sender, EventArgs e) { }
+        private void Rashodomer4_CB_CheckedChanged(object sender, EventArgs e) { }
     }
 }
-

--- a/Forms/MetersSetupForm.resx
+++ b/Forms/MetersSetupForm.resx
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="backgroundWorker1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
+</root>


### PR DESCRIPTION
## Summary
- replace dynamic MetersSetupForm with designer-based implementation derived from legacy Second form
- stub out all referenced event handlers for future logic

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop".)*

------
https://chatgpt.com/codex/tasks/task_e_68a45043dd7c83318eb85d91f5122877