### PR TITLE
Add uniqueness constraints and deduplicate meter import

### DIFF
--- a/Client/Forms/Admin/ConfigurationForm.Designer.cs
+++ b/Client/Forms/Admin/ConfigurationForm.Designer.cs
@@ -17,6 +17,9 @@ namespace PoverkaWinForms.Forms.Admin
         private System.Windows.Forms.Button btnChangeMyPassword;
         private System.Windows.Forms.TableLayoutPanel pnlLoading;
         private System.Windows.Forms.ProgressBar progressBar;
+        private System.Windows.Forms.TextBox txtCsvPath;
+        private System.Windows.Forms.Button btnAddFromFile;
+        private System.Windows.Forms.Button btnProcessFile;
 
         /// <summary>
         /// Clean up any resources being used.
@@ -46,6 +49,9 @@ namespace PoverkaWinForms.Forms.Admin
             btnEditUser = new Button();
             btnCreateUser = new Button();
             tabSettings = new TabPage();
+            txtCsvPath = new TextBox();
+            btnAddFromFile = new Button();
+            btnProcessFile = new Button();
             tabControl.SuspendLayout();
             tabUsers.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)gridUsers).BeginInit();
@@ -171,6 +177,9 @@ namespace PoverkaWinForms.Forms.Admin
             //
             // tabSettings
             //
+            tabSettings.Controls.Add(btnProcessFile);
+            tabSettings.Controls.Add(btnAddFromFile);
+            tabSettings.Controls.Add(txtCsvPath);
             tabSettings.Location = new Point(4, 29);
             tabSettings.Name = "tabSettings";
             tabSettings.Padding = new Padding(3);
@@ -178,6 +187,37 @@ namespace PoverkaWinForms.Forms.Admin
             tabSettings.TabIndex = 1;
             tabSettings.Text = "Настройки";
             tabSettings.UseVisualStyleBackColor = true;
+            //
+            // txtCsvPath
+            //
+            txtCsvPath.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            txtCsvPath.Location = new Point(8, 8);
+            txtCsvPath.Name = "txtCsvPath";
+            txtCsvPath.ReadOnly = true;
+            txtCsvPath.Size = new Size(760, 27);
+            txtCsvPath.TabIndex = 0;
+            //
+            // btnAddFromFile
+            //
+            btnAddFromFile.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            btnAddFromFile.Location = new Point(774, 6);
+            btnAddFromFile.Name = "btnAddFromFile";
+            btnAddFromFile.Size = new Size(175, 29);
+            btnAddFromFile.TabIndex = 1;
+            btnAddFromFile.Text = "Добавить из файла";
+            btnAddFromFile.UseVisualStyleBackColor = true;
+            btnAddFromFile.Click += btnAddFromFile_Click;
+            //
+            // btnProcessFile
+            //
+            btnProcessFile.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            btnProcessFile.Location = new Point(774, 41);
+            btnProcessFile.Name = "btnProcessFile";
+            btnProcessFile.Size = new Size(175, 29);
+            btnProcessFile.TabIndex = 2;
+            btnProcessFile.Text = "Обработать";
+            btnProcessFile.UseVisualStyleBackColor = true;
+            btnProcessFile.Click += btnProcessFile_Click;
             //
             // ConfigurationForm
             //

--- a/Client/Forms/Admin/ConfigurationForm.cs
+++ b/Client/Forms/Admin/ConfigurationForm.cs
@@ -9,15 +9,17 @@ namespace PoverkaWinForms.Forms.Admin;
 public partial class ConfigurationForm : Form
 {
     private readonly UserService? _users;
+    private readonly MeterImportService? _import;
 
     public ConfigurationForm()
     {
         InitializeComponent();
     }
 
-    public ConfigurationForm(UserService users) : this()
+    public ConfigurationForm(UserService users, MeterImportService import) : this()
     {
         _users = users;
+        _import = import;
     }
 
     private void gridUsers_SelectionChanged(object? sender, EventArgs e)
@@ -103,6 +105,33 @@ public partial class ConfigurationForm : Form
         pnlLoading.Visible = loading;
         panelTop.Enabled = !loading;
         gridUsers.Enabled = !loading;
+    }
+
+    private void btnAddFromFile_Click(object? sender, EventArgs e)
+    {
+        using var dialog = new OpenFileDialog
+        {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+        };
+
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            txtCsvPath.Text = dialog.FileName;
+        }
+    }
+
+    private async void btnProcessFile_Click(object? sender, EventArgs e)
+    {
+        if (_import is null || string.IsNullOrWhiteSpace(txtCsvPath.Text))
+        {
+            return;
+        }
+
+        await FormHelper.RunSafeAsync(async () =>
+        {
+            await _import.ImportAsync(txtCsvPath.Text);
+            MessageBox.Show("Файл обработан");
+        });
     }
 }
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -32,6 +32,7 @@ namespace PoverkaWinForms
             services.AddHttpClient("ApiClient")
                 .AddHttpMessageHandler<HttpErrorHandler>();
             services.AddTransient<UserService>();
+            services.AddTransient<MeterImportService>();
 
             services.AddScoped<MetersSetupForm>();
             services.AddScoped<ConfigurationForm>();

--- a/Client/Services/MeterImportService.cs
+++ b/Client/Services/MeterImportService.cs
@@ -1,0 +1,230 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using PoverkaWinForms.Settings;
+
+namespace PoverkaWinForms.Services;
+
+public class MeterImportService
+{
+    private readonly HttpClient _http;
+    private readonly TokenService _tokens;
+    private readonly Dictionary<string, int> _meterTypes = new();
+    private readonly Dictionary<string, int> _registrations = new();
+    private readonly HashSet<(int registrationId, string name)> _modifications = new();
+
+    public MeterImportService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
+    {
+        _http = factory.CreateClient("ApiClient");
+        _http.BaseAddress = new Uri(settings.Authority);
+        _tokens = tokens;
+    }
+
+    public async Task ImportAsync(string path)
+    {
+        var token = await _tokens.GetAccessTokenAsync();
+        if (token is null) return;
+
+        await LoadExistingAsync(token);
+
+        var culture = CultureInfo.GetCultureInfo("ru-RU");
+        var lines = await File.ReadAllLinesAsync(path);
+        foreach (var line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var parts = line.Split(';');
+            var fullName = parts[0];
+            var type = parts[1];
+            var className = parts[2];
+            var modificationName = parts[3];
+            var registrationNumber = parts[4];
+            var verificationInterval = short.Parse(parts[5], culture);
+            var impulseWeight = double.Parse(parts[7], culture);
+            var qmin = double.Parse(parts[8], culture);
+            var qt1 = double.Parse(parts[9], culture);
+            var qt2 = double.Parse(parts[10], culture);
+            var qmax = double.Parse(parts[11], culture);
+            var checkpoint1 = double.Parse(parts[12], culture);
+            var checkpoint2 = double.Parse(parts[13], culture);
+            var checkpoint3 = double.Parse(parts[14], culture);
+            double? checkpoint4 = string.IsNullOrWhiteSpace(parts[15]) ? null : double.Parse(parts[15], culture);
+            var numberOfMeasurements = byte.Parse(parts[16], culture);
+            var minPulseCount = short.Parse(parts[17], culture);
+            var measurementDuration = short.Parse(parts[18], culture);
+            var verificationMethodology = parts[19];
+            var relativeErrorQt1_Qmax = byte.Parse(parts[20], culture);
+            var relativeErrorQt2_Qt1 = byte.Parse(parts[21], culture);
+            var relativeErrorQmin_Qt2 = byte.Parse(parts[22], culture);
+            var registrationDate = DateOnly.Parse(parts[23], culture);
+            var endDate = DateOnly.Parse(parts[24], culture);
+            var relativeErrorWithStandartValue = byte.Parse(parts[25], culture);
+            var hasVerificationModeByV = parts[26].Equals("да", StringComparison.OrdinalIgnoreCase);
+            var hasVerificationModeByG = parts[27].Equals("да", StringComparison.OrdinalIgnoreCase);
+
+            var meterTypeId = await CreateMeterTypeAsync(token, fullName, type);
+            var registrationId = await CreateRegistrationAsync(token, meterTypeId, registrationNumber, verificationInterval,
+                verificationMethodology, relativeErrorQt1_Qmax, relativeErrorQt2_Qt1, relativeErrorQmin_Qt2, registrationDate,
+                endDate, hasVerificationModeByV, hasVerificationModeByG);
+
+            await CreateModificationAsync(token, registrationId, modificationName, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1,
+                checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDuration,
+                relativeErrorWithStandartValue);
+        }
+    }
+
+    private async Task LoadExistingAsync(string token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/metertypes");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        if (response.IsSuccessStatusCode)
+        {
+            var items = await response.Content.ReadFromJsonAsync<List<MeterTypeDto>>();
+            if (items != null)
+            {
+                foreach (var m in items)
+                {
+                    _meterTypes[m.Type] = m.Id;
+                }
+            }
+        }
+
+        request = new HttpRequestMessage(HttpMethod.Get, "/api/registrations");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        response = await _http.SendAsync(request);
+        if (response.IsSuccessStatusCode)
+        {
+            var items = await response.Content.ReadFromJsonAsync<List<RegistrationDto>>();
+            if (items != null)
+            {
+                foreach (var r in items)
+                {
+                    _registrations[r.RegistrationNumber] = r.Id;
+                }
+            }
+        }
+
+        request = new HttpRequestMessage(HttpMethod.Get, "/api/modifications");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        response = await _http.SendAsync(request);
+        if (response.IsSuccessStatusCode)
+        {
+            var items = await response.Content.ReadFromJsonAsync<List<ModificationDto>>();
+            if (items != null)
+            {
+                foreach (var m in items)
+                {
+                    _modifications.Add((m.RegistrationId, m.Name));
+                }
+            }
+        }
+    }
+
+    private async Task<int> CreateMeterTypeAsync(string token, string fullName, string type)
+    {
+        if (_meterTypes.TryGetValue(type, out var existingId))
+        {
+            return existingId;
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/metertypes")
+        {
+            Content = JsonContent.Create(new { EditorName = "import", Type = type, FullName = fullName })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var id = await response.Content.ReadFromJsonAsync<int>();
+        _meterTypes[type] = id;
+        return id;
+    }
+
+    private async Task<int> CreateRegistrationAsync(string token, int meterTypeId, string registrationNumber,
+        short verificationInterval, string verificationMethodology, byte relativeErrorQt1_Qmax,
+        byte relativeErrorQt2_Qt1, byte relativeErrorQmin_Qt2, DateOnly registrationDate, DateOnly endDate,
+        bool hasVerificationModeByV, bool hasVerificationModeByG)
+    {
+        if (_registrations.TryGetValue(registrationNumber, out var existingId))
+        {
+            return existingId;
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/registrations")
+        {
+            Content = JsonContent.Create(new
+            {
+                EditorName = "import",
+                MeterTypeId = meterTypeId,
+                RegistrationNumber = registrationNumber,
+                VerificationInterval = verificationInterval,
+                VerificationMethodology = verificationMethodology,
+                RelativeErrorQt1_Qmax = relativeErrorQt1_Qmax,
+                RelativeErrorQt2_Qt1 = relativeErrorQt2_Qt1,
+                RelativeErrorQmin_Qt2 = relativeErrorQmin_Qt2,
+                RegistrationDate = registrationDate,
+                EndDate = endDate,
+                HasVerificationModeByV = hasVerificationModeByV,
+                HasVerificationModeByG = hasVerificationModeByG
+            })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var id = await response.Content.ReadFromJsonAsync<int>();
+        _registrations[registrationNumber] = id;
+        return id;
+    }
+
+    private async Task<int?> CreateModificationAsync(string token, int registrationId, string name, string className,
+        double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1,
+        double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements,
+        short minPulseCount, short measurementDuration, byte relativeErrorWithStandartValue)
+    {
+        if (!_modifications.Add((registrationId, name)))
+        {
+            return null;
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/modifications")
+        {
+            Content = JsonContent.Create(new
+            {
+                EditorName = "import",
+                RegistrationId = registrationId,
+                Name = name,
+                ClassName = className,
+                ImpulseWeight = impulseWeight,
+                Qmin = qmin,
+                Qt1 = qt1,
+                Qt2 = qt2,
+                Qmax = qmax,
+                Checkpoint1 = checkpoint1,
+                Checkpoint2 = checkpoint2,
+                Checkpoint3 = checkpoint3,
+                Checkpoint4 = checkpoint4,
+                NumberOfMeasurements = numberOfMeasurements,
+                MinPulseCount = minPulseCount,
+                MeasurementDurationInSeconds = measurementDuration,
+                RelativeErrorWithStandartValue = relativeErrorWithStandartValue
+            })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var id = await response.Content.ReadFromJsonAsync<int>();
+        _modifications.Add((registrationId, name));
+        return id;
+    }
+
+    private record MeterTypeDto(int Id, string Type);
+    private record RegistrationDto(int Id, string RegistrationNumber);
+    private record ModificationDto(int Id, int RegistrationId, string Name);
+}

--- a/Server/Data/Configurations/MeterTypeConfiguration.cs
+++ b/Server/Data/Configurations/MeterTypeConfiguration.cs
@@ -15,5 +15,6 @@ public class MeterTypeConfiguration : IEntityTypeConfiguration<MeterType>
         builder.Property(e => e.EditorName).HasMaxLength(256);
         builder.Property(e => e.CreatedAt);
         builder.Property(e => e.UpdatedAt);
+        builder.HasIndex(e => e.Type).IsUnique();
     }
 }

--- a/Server/Data/Configurations/ModificationConfiguration.cs
+++ b/Server/Data/Configurations/ModificationConfiguration.cs
@@ -10,6 +10,7 @@ public class ModificationConfiguration : IEntityTypeConfiguration<Modification>
     {
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id).UseIdentityByDefaultColumn();
+        builder.Property(e => e.Name).HasMaxLength(100);
         builder.Property(e => e.ClassName).HasMaxLength(5);
         builder.Property(e => e.ImpulseWeight).HasColumnType("double precision");
         builder.Property(e => e.Qmin).HasColumnType("double precision");
@@ -23,6 +24,7 @@ public class ModificationConfiguration : IEntityTypeConfiguration<Modification>
         builder.Property(e => e.EditorName).HasMaxLength(256);
         builder.Property(e => e.CreatedAt);
         builder.Property(e => e.UpdatedAt);
+        builder.HasIndex(e => new { e.RegistrationId, e.Name }).IsUnique();
         builder.HasOne<Registration>()
             .WithMany()
             .HasForeignKey(e => e.RegistrationId);

--- a/Server/Data/Configurations/RegistrationConfiguration.cs
+++ b/Server/Data/Configurations/RegistrationConfiguration.cs
@@ -15,6 +15,7 @@ public class RegistrationConfiguration : IEntityTypeConfiguration<Registration>
         builder.Property(e => e.EditorName).HasMaxLength(256);
         builder.Property(e => e.CreatedAt);
         builder.Property(e => e.UpdatedAt);
+        builder.HasIndex(e => e.RegistrationNumber).IsUnique();
         builder.HasOne<MeterType>()
             .WithMany()
             .HasForeignKey(e => e.MeterTypeId);

--- a/Server/Domain/Modification.cs
+++ b/Server/Domain/Modification.cs
@@ -4,9 +4,28 @@ namespace PoverkaServer.Domain;
 
 public class Modification
 {
-    public Modification(string editorName, int registrationId, string className, double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1, double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements, short minPulseCount, short measurementDurationInSeconds, byte relativeErrorWithStandartValue)
+    public Modification(
+        string editorName,
+        int registrationId,
+        string name,
+        string className,
+        double impulseWeight,
+        double qmin,
+        double qt1,
+        double qt2,
+        double qmax,
+        double checkpoint1,
+        double checkpoint2,
+        double checkpoint3,
+        double? checkpoint4,
+        byte numberOfMeasurements,
+        short minPulseCount,
+        short measurementDurationInSeconds,
+        byte relativeErrorWithStandartValue)
     {
-        Set(editorName, registrationId, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
+        Set(editorName, registrationId, name, className, impulseWeight, qmin, qt1, qt2, qmax,
+            checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements,
+            minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
         CreatedAt = UpdatedAt = DateTime.UtcNow;
     }
 
@@ -18,6 +37,7 @@ public class Modification
 
     public int Id { get; private set; }
     public int RegistrationId { get; private set; }
+    public string Name { get; private set; }
     public string ClassName { get; private set; }
     public double ImpulseWeight { get; private set; }
     public double Qmin { get; private set; }
@@ -35,14 +55,51 @@ public class Modification
     public string EditorName { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public DateTime UpdatedAt { get; private set; }
-    public void Update(string editorName, int registrationId, string className, double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1, double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements, short minPulseCount, short measurementDurationInSeconds, byte relativeErrorWithStandartValue)
+
+    public void Update(
+        string editorName,
+        int registrationId,
+        string name,
+        string className,
+        double impulseWeight,
+        double qmin,
+        double qt1,
+        double qt2,
+        double qmax,
+        double checkpoint1,
+        double checkpoint2,
+        double checkpoint3,
+        double? checkpoint4,
+        byte numberOfMeasurements,
+        short minPulseCount,
+        short measurementDurationInSeconds,
+        byte relativeErrorWithStandartValue)
     {
-        Set(editorName, registrationId, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
+        Set(editorName, registrationId, name, className, impulseWeight, qmin, qt1, qt2, qmax,
+            checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements,
+            minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
         UpdatedAt = DateTime.UtcNow;
     }
 
-    [MemberNotNull(nameof(ClassName), nameof(EditorName))]
-    private void Set(string editorName, int registrationId, string className, double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1, double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements, short minPulseCount, short measurementDurationInSeconds, byte relativeErrorWithStandartValue)
+    [MemberNotNull(nameof(Name), nameof(ClassName), nameof(EditorName))]
+    private void Set(
+        string editorName,
+        int registrationId,
+        string name,
+        string className,
+        double impulseWeight,
+        double qmin,
+        double qt1,
+        double qt2,
+        double qmax,
+        double checkpoint1,
+        double checkpoint2,
+        double checkpoint3,
+        double? checkpoint4,
+        byte numberOfMeasurements,
+        short minPulseCount,
+        short measurementDurationInSeconds,
+        byte relativeErrorWithStandartValue)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(registrationId, nameof(registrationId));
         ArgumentOutOfRangeException.ThrowIfNegative(impulseWeight, nameof(impulseWeight));
@@ -64,6 +121,7 @@ public class Modification
 
         EditorName = editorName;
         RegistrationId = registrationId;
+        Name = name;
         ClassName = className;
         ImpulseWeight = impulseWeight;
         Qmin = qmin;
@@ -80,4 +138,3 @@ public class Modification
         RelativeErrorWithStandartValue = relativeErrorWithStandartValue;
     }
 }
-

--- a/Server/Endpoints/Modifications/ModificationEndpoints.cs
+++ b/Server/Endpoints/Modifications/ModificationEndpoints.cs
@@ -41,13 +41,48 @@ public static class ModificationEndpoints
 
     private static async Task<Ok<int>> CreateModification([Validate] ModificationRequest request, ModificationService service)
     {
-        var modification = await service.CreateAsync(request.EditorName, request.RegistrationId, request.ClassName, request.ImpulseWeight, request.Qmin, request.Qt1, request.Qt2, request.Qmax, request.Checkpoint1, request.Checkpoint2, request.Checkpoint3, request.Checkpoint4, request.NumberOfMeasurements, request.MinPulseCount, request.MeasurementDurationInSeconds, request.RelativeErrorWithStandartValue);
+        var modification = await service.CreateAsync(
+            request.EditorName,
+            request.RegistrationId,
+            request.Name,
+            request.ClassName,
+            request.ImpulseWeight,
+            request.Qmin,
+            request.Qt1,
+            request.Qt2,
+            request.Qmax,
+            request.Checkpoint1,
+            request.Checkpoint2,
+            request.Checkpoint3,
+            request.Checkpoint4,
+            request.NumberOfMeasurements,
+            request.MinPulseCount,
+            request.MeasurementDurationInSeconds,
+            request.RelativeErrorWithStandartValue);
         return TypedResults.Ok(modification.Id);
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateModification(int id, [Validate] ModificationRequest request, ModificationService service)
     {
-        var updated = await service.UpdateAsync(id, request.EditorName, request.RegistrationId, request.ClassName, request.ImpulseWeight, request.Qmin, request.Qt1, request.Qt2, request.Qmax, request.Checkpoint1, request.Checkpoint2, request.Checkpoint3, request.Checkpoint4, request.NumberOfMeasurements, request.MinPulseCount, request.MeasurementDurationInSeconds, request.RelativeErrorWithStandartValue);
+        var updated = await service.UpdateAsync(
+            id,
+            request.EditorName,
+            request.RegistrationId,
+            request.Name,
+            request.ClassName,
+            request.ImpulseWeight,
+            request.Qmin,
+            request.Qt1,
+            request.Qt2,
+            request.Qmax,
+            request.Checkpoint1,
+            request.Checkpoint2,
+            request.Checkpoint3,
+            request.Checkpoint4,
+            request.NumberOfMeasurements,
+            request.MinPulseCount,
+            request.MeasurementDurationInSeconds,
+            request.RelativeErrorWithStandartValue);
         return updated ? TypedResults.NoContent() : TypedResults.NotFound();
     }
 

--- a/Server/Endpoints/Modifications/Requests/ModificationRequest.cs
+++ b/Server/Endpoints/Modifications/Requests/ModificationRequest.cs
@@ -11,6 +11,9 @@ public class ModificationRequest : IValidatableObject
     [Range(1, int.MaxValue, ErrorMessage = "RegistrationId должен быть положительным.")]
     public required int RegistrationId { get; init; }
 
+    [StringLength(100, MinimumLength = 1, ErrorMessage = "Указана недопустимая длина Name, допускается длина от 1 до 100 символов.")]
+    public required string Name { get; init; }
+
     [StringLength(5, MinimumLength = 1, ErrorMessage = "Указана недопустимая длина ClassName, допускается длина от 1 до 5 символов.")]
     public required string ClassName { get; init; }
 

--- a/Server/Endpoints/Modifications/Responses/ModificationResponse.cs
+++ b/Server/Endpoints/Modifications/Responses/ModificationResponse.cs
@@ -13,6 +13,7 @@ public class ModificationResponse
 
     public int Id => _modification.Id;
     public int RegistrationId => _modification.RegistrationId;
+    public string Name => _modification.Name;
     public string ClassName => _modification.ClassName;
     public double ImpulseWeight => _modification.ImpulseWeight;
     public double Qmin => _modification.Qmin;

--- a/Server/Migrations/ApplicationDb/20250825150328_AddMeterRegistry.Designer.cs
+++ b/Server/Migrations/ApplicationDb/20250825150328_AddMeterRegistry.Designer.cs
@@ -12,7 +12,7 @@ using PoverkaServer.Data;
 namespace PoverkaServer.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250825051842_AddMeterRegistry")]
+    [Migration("20250825150328_AddMeterRegistry")]
     partial class AddMeterRegistry
     {
         /// <inheritdoc />
@@ -188,6 +188,9 @@ namespace PoverkaServer.Migrations.ApplicationDb
 
                     b.HasKey("Id");
 
+                    b.HasIndex("Type")
+                        .IsUnique();
+
                     b.ToTable("MeterTypes");
                 });
 
@@ -233,6 +236,11 @@ namespace PoverkaServer.Migrations.ApplicationDb
                     b.Property<short>("MinPulseCount")
                         .HasColumnType("smallint");
 
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
                     b.Property<byte>("NumberOfMeasurements")
                         .HasColumnType("smallint");
 
@@ -259,7 +267,8 @@ namespace PoverkaServer.Migrations.ApplicationDb
 
                     b.HasKey("Id");
 
-                    b.HasIndex("RegistrationId");
+                    b.HasIndex("RegistrationId", "Name")
+                        .IsUnique();
 
                     b.ToTable("Modifications");
                 });
@@ -323,6 +332,9 @@ namespace PoverkaServer.Migrations.ApplicationDb
                     b.HasKey("Id");
 
                     b.HasIndex("MeterTypeId");
+
+                    b.HasIndex("RegistrationNumber")
+                        .IsUnique();
 
                     b.ToTable("Registrations");
                 });

--- a/Server/Migrations/ApplicationDb/20250825150328_AddMeterRegistry.cs
+++ b/Server/Migrations/ApplicationDb/20250825150328_AddMeterRegistry.cs
@@ -68,6 +68,7 @@ namespace PoverkaServer.Migrations.ApplicationDb
                     Id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     RegistrationId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     ClassName = table.Column<string>(type: "character varying(5)", maxLength: 5, nullable: false),
                     ImpulseWeight = table.Column<double>(type: "double precision", nullable: false),
                     Qmin = table.Column<double>(type: "double precision", nullable: false),
@@ -98,14 +99,27 @@ namespace PoverkaServer.Migrations.ApplicationDb
                 });
 
             migrationBuilder.CreateIndex(
-                name: "IX_Modifications_RegistrationId",
+                name: "IX_MeterTypes_Type",
+                table: "MeterTypes",
+                column: "Type",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Modifications_RegistrationId_Name",
                 table: "Modifications",
-                column: "RegistrationId");
+                columns: new[] { "RegistrationId", "Name" },
+                unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Registrations_MeterTypeId",
                 table: "Registrations",
                 column: "MeterTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Registrations_RegistrationNumber",
+                table: "Registrations",
+                column: "RegistrationNumber",
+                unique: true);
         }
 
         /// <inheritdoc />

--- a/Server/Migrations/ApplicationDb/ApplicationDbContextModelSnapshot.cs
+++ b/Server/Migrations/ApplicationDb/ApplicationDbContextModelSnapshot.cs
@@ -185,6 +185,9 @@ namespace PoverkaServer.Migrations.ApplicationDb
 
                     b.HasKey("Id");
 
+                    b.HasIndex("Type")
+                        .IsUnique();
+
                     b.ToTable("MeterTypes");
                 });
 
@@ -230,6 +233,11 @@ namespace PoverkaServer.Migrations.ApplicationDb
                     b.Property<short>("MinPulseCount")
                         .HasColumnType("smallint");
 
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
                     b.Property<byte>("NumberOfMeasurements")
                         .HasColumnType("smallint");
 
@@ -256,7 +264,8 @@ namespace PoverkaServer.Migrations.ApplicationDb
 
                     b.HasKey("Id");
 
-                    b.HasIndex("RegistrationId");
+                    b.HasIndex("RegistrationId", "Name")
+                        .IsUnique();
 
                     b.ToTable("Modifications");
                 });
@@ -320,6 +329,9 @@ namespace PoverkaServer.Migrations.ApplicationDb
                     b.HasKey("Id");
 
                     b.HasIndex("MeterTypeId");
+
+                    b.HasIndex("RegistrationNumber")
+                        .IsUnique();
 
                     b.ToTable("Registrations");
                 });

--- a/Server/Services/ModificationService.cs
+++ b/Server/Services/ModificationService.cs
@@ -17,22 +17,57 @@ public class ModificationService
 
     public Task<Modification?> GetAsync(int id) => _db.Modifications.FirstOrDefaultAsync(m => m.Id == id);
 
-    public async Task<Modification> CreateAsync(string editorName, int registrationId, string className, double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1, double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements, short minPulseCount, short measurementDurationInSeconds, byte relativeErrorWithStandartValue)
+    public async Task<Modification> CreateAsync(
+        string editorName,
+        int registrationId,
+        string name,
+        string className,
+        double impulseWeight,
+        double qmin,
+        double qt1,
+        double qt2,
+        double qmax,
+        double checkpoint1,
+        double checkpoint2,
+        double checkpoint3,
+        double? checkpoint4,
+        byte numberOfMeasurements,
+        short minPulseCount,
+        short measurementDurationInSeconds,
+        byte relativeErrorWithStandartValue)
     {
-        var modification = new Modification(editorName, registrationId, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
+        var modification = new Modification(editorName, registrationId, name, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
         _db.Modifications.Add(modification);
         await _db.SaveChangesAsync();
         return modification;
     }
 
-    public async Task<bool> UpdateAsync(int id, string editorName, int registrationId, string className, double impulseWeight, double qmin, double qt1, double qt2, double qmax, double checkpoint1, double checkpoint2, double checkpoint3, double? checkpoint4, byte numberOfMeasurements, short minPulseCount, short measurementDurationInSeconds, byte relativeErrorWithStandartValue)
+    public async Task<bool> UpdateAsync(
+        int id,
+        string editorName,
+        int registrationId,
+        string name,
+        string className,
+        double impulseWeight,
+        double qmin,
+        double qt1,
+        double qt2,
+        double qmax,
+        double checkpoint1,
+        double checkpoint2,
+        double checkpoint3,
+        double? checkpoint4,
+        byte numberOfMeasurements,
+        short minPulseCount,
+        short measurementDurationInSeconds,
+        byte relativeErrorWithStandartValue)
     {
         var modification = await _db.Modifications.FindAsync(id);
         if (modification is null)
         {
             return false;
         }
-        modification.Update(editorName, registrationId, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
+        modification.Update(editorName, registrationId, name, className, impulseWeight, qmin, qt1, qt2, qmax, checkpoint1, checkpoint2, checkpoint3, checkpoint4, numberOfMeasurements, minPulseCount, measurementDurationInSeconds, relativeErrorWithStandartValue);
         await _db.SaveChangesAsync();
         return true;
     }


### PR DESCRIPTION
## Summary
- add unique indexes for meter types, registrations, and modifications, introducing a `Name` field for modifications
- skip creating duplicate meter types, registrations, and modifications during CSV import

## Testing
- `dotnet restore Poverka.sln`
- `dotnet build Poverka.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ac3df7c44c833192635b0474a74111