### PR TITLE
Align flowmeter controls and simplify toggle logic

### DIFF
--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -262,6 +262,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
             this.Flow1_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow1_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow1_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // GosReestr
             // 
@@ -460,6 +461,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow2_Name_SI_CB.TabIndex = 20;
             this.Flow2_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow2_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow2_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label13
             // 
@@ -641,6 +643,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow3_Name_SI_CB.TabIndex = 20;
             this.Flow3_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow3_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow3_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label20
             // 
@@ -821,6 +824,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow4_Name_SI_CB.TabIndex = 20;
             this.Flow4_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow4_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow4_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label28
             // 
@@ -1001,6 +1005,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow5_Name_SI_CB.TabIndex = 20;
             this.Flow5_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow5_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow5_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label36
             // 
@@ -1182,6 +1187,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow6_Name_SI_CB.TabIndex = 20;
             this.Flow6_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow6_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow6_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label44
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -249,9 +249,9 @@ namespace PoverkaWinForms.Forms.Verifier
             this.label2.Text = "Тип";
             // 
             // Flow1_Name_SI_CB
-            // 
+            //
             this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow1_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow1_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow1_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow1_Name_SI_CB.FormattingEnabled = true;
             this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -261,6 +261,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow1_Name_SI_CB.TabIndex = 20;
             this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
             this.Flow1_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow1_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // GosReestr
             // 
@@ -449,7 +450,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow2_Name_SI_CB
             // 
             this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow2_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow2_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow2_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow2_Name_SI_CB.FormattingEnabled = true;
             this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -458,6 +459,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow2_Name_SI_CB.TabIndex = 20;
             this.Flow2_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow2_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // label13
             // 
@@ -629,7 +631,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow3_Name_SI_CB
             // 
             this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow3_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow3_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow3_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow3_Name_SI_CB.FormattingEnabled = true;
             this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -638,6 +640,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow3_Name_SI_CB.TabIndex = 20;
             this.Flow3_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow3_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // label20
             // 
@@ -808,7 +811,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow4_Name_SI_CB
             // 
             this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow4_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow4_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow4_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow4_Name_SI_CB.FormattingEnabled = true;
             this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -817,6 +820,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow4_Name_SI_CB.TabIndex = 20;
             this.Flow4_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow4_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // label28
             // 
@@ -987,7 +991,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow5_Name_SI_CB
             // 
             this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow5_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow5_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow5_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow5_Name_SI_CB.FormattingEnabled = true;
             this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -996,6 +1000,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow5_Name_SI_CB.TabIndex = 20;
             this.Flow5_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow5_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // label36
             // 
@@ -1167,7 +1172,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow6_Name_SI_CB
             // 
             this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow6_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow6_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.Flow6_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow6_Name_SI_CB.FormattingEnabled = true;
             this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
@@ -1176,6 +1181,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow6_Name_SI_CB.TabIndex = 20;
             this.Flow6_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
+            this.Flow6_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
             // 
             // label44
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -341,7 +341,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer1_CB.Name = "Rashodomer1_CB";
             this.Rashodomer1_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer1_CB.TabIndex = 36;
-            this.Rashodomer1_CB.Text = "Включить";
+            this.Rashodomer1_CB.Text = "Установлен";
             this.Rashodomer1_CB.UseVisualStyleBackColor = true;
             this.Rashodomer1_CB.CheckedChanged += new System.EventHandler(this.Rashodomer1_CB_CheckedChanged);
             // 
@@ -1258,7 +1258,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer2_CB.Name = "Rashodomer2_CB";
             this.Rashodomer2_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer2_CB.TabIndex = 45;
-            this.Rashodomer2_CB.Text = "Включить";
+            this.Rashodomer2_CB.Text = "Установлен";
             this.Rashodomer2_CB.UseVisualStyleBackColor = true;
             this.Rashodomer2_CB.CheckedChanged += new System.EventHandler(this.Rashodomer2_CB_CheckedChanged);
             // 
@@ -1271,7 +1271,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer3_CB.Name = "Rashodomer3_CB";
             this.Rashodomer3_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer3_CB.TabIndex = 46;
-            this.Rashodomer3_CB.Text = "Включить";
+            this.Rashodomer3_CB.Text = "Установлен";
             this.Rashodomer3_CB.UseVisualStyleBackColor = true;
             this.Rashodomer3_CB.CheckedChanged += new System.EventHandler(this.Rashodomer3_CB_CheckedChanged);
             // 
@@ -1284,7 +1284,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer6_CB.Name = "Rashodomer6_CB";
             this.Rashodomer6_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer6_CB.TabIndex = 49;
-            this.Rashodomer6_CB.Text = "Включить";
+            this.Rashodomer6_CB.Text = "Установлен";
             this.Rashodomer6_CB.UseVisualStyleBackColor = true;
             this.Rashodomer6_CB.CheckedChanged += new System.EventHandler(this.Rashodomer6_CB_CheckedChanged);
             // 
@@ -1297,7 +1297,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer5_CB.Name = "Rashodomer5_CB";
             this.Rashodomer5_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer5_CB.TabIndex = 48;
-            this.Rashodomer5_CB.Text = "Включить";
+            this.Rashodomer5_CB.Text = "Установлен";
             this.Rashodomer5_CB.UseVisualStyleBackColor = true;
             this.Rashodomer5_CB.CheckedChanged += new System.EventHandler(this.Rashodomer5_CB_CheckedChanged);
             // 
@@ -1310,7 +1310,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer4_CB.Name = "Rashodomer4_CB";
             this.Rashodomer4_CB.Size = new System.Drawing.Size(102, 21);
             this.Rashodomer4_CB.TabIndex = 47;
-            this.Rashodomer4_CB.Text = "Включить";
+            this.Rashodomer4_CB.Text = "Установлен";
             this.Rashodomer4_CB.UseVisualStyleBackColor = true;
             this.Rashodomer4_CB.CheckedChanged += new System.EventHandler(this.Rashodomer4_CB_CheckedChanged);
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -28,1356 +28,1341 @@ namespace PoverkaWinForms.Forms.Verifier
         /// </summary>
         private void InitializeComponent()
         {
-            this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
-            this.label7 = new System.Windows.Forms.Label();
-            this.Flow1_Document_CB = new System.Windows.Forms.ComboBox();
-            this.Flow1_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.Flow1_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.Flow1_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.Flow1_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.Flow1_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.GosReestr = new System.Windows.Forms.Label();
-            this.Flow1_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.Rashodomer1_GB = new System.Windows.Forms.GroupBox();
-            this.label8 = new System.Windows.Forms.Label();
-            this.Rashodomer1_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer2_GB = new System.Windows.Forms.GroupBox();
-            this.label10 = new System.Windows.Forms.Label();
-            this.Flow2_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.label11 = new System.Windows.Forms.Label();
-            this.Flow2_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.Flow2_Document_CB = new System.Windows.Forms.ComboBox();
-            this.label12 = new System.Windows.Forms.Label();
-            this.Flow2_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.Flow2_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.label13 = new System.Windows.Forms.Label();
-            this.label14 = new System.Windows.Forms.Label();
-            this.label15 = new System.Windows.Forms.Label();
-            this.Flow2_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label16 = new System.Windows.Forms.Label();
-            this.Flow2_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label17 = new System.Windows.Forms.Label();
-            this.Rashodomer3_GB = new System.Windows.Forms.GroupBox();
-            this.label9 = new System.Windows.Forms.Label();
-            this.Flow3_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.label18 = new System.Windows.Forms.Label();
-            this.Flow3_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.Flow3_Document_CB = new System.Windows.Forms.ComboBox();
-            this.label19 = new System.Windows.Forms.Label();
-            this.Flow3_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.Flow3_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.label20 = new System.Windows.Forms.Label();
-            this.label21 = new System.Windows.Forms.Label();
-            this.label22 = new System.Windows.Forms.Label();
-            this.Flow3_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label23 = new System.Windows.Forms.Label();
-            this.Flow3_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label24 = new System.Windows.Forms.Label();
-            this.Rashodomer4_GB = new System.Windows.Forms.GroupBox();
-            this.label25 = new System.Windows.Forms.Label();
-            this.Flow4_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.label26 = new System.Windows.Forms.Label();
-            this.Flow4_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.Flow4_Document_CB = new System.Windows.Forms.ComboBox();
-            this.label27 = new System.Windows.Forms.Label();
-            this.Flow4_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.Flow4_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.label28 = new System.Windows.Forms.Label();
-            this.label29 = new System.Windows.Forms.Label();
-            this.label30 = new System.Windows.Forms.Label();
-            this.Flow4_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label31 = new System.Windows.Forms.Label();
-            this.Flow4_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label32 = new System.Windows.Forms.Label();
-            this.Rashodomer5_GB = new System.Windows.Forms.GroupBox();
-            this.label33 = new System.Windows.Forms.Label();
-            this.Flow5_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.label34 = new System.Windows.Forms.Label();
-            this.Flow5_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.Flow5_Document_CB = new System.Windows.Forms.ComboBox();
-            this.label35 = new System.Windows.Forms.Label();
-            this.Flow5_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.Flow5_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.label36 = new System.Windows.Forms.Label();
-            this.label37 = new System.Windows.Forms.Label();
-            this.label38 = new System.Windows.Forms.Label();
-            this.Flow5_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label39 = new System.Windows.Forms.Label();
-            this.Flow5_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label40 = new System.Windows.Forms.Label();
-            this.Rashodomer6_GB = new System.Windows.Forms.GroupBox();
-            this.label41 = new System.Windows.Forms.Label();
-            this.Flow6_Diameter_CB = new System.Windows.Forms.ComboBox();
-            this.label42 = new System.Windows.Forms.Label();
-            this.Flow6_GosReestr_CB = new System.Windows.Forms.ComboBox();
-            this.Flow6_Document_CB = new System.Windows.Forms.ComboBox();
-            this.label43 = new System.Windows.Forms.Label();
-            this.Flow6_WeightImpulse_TB = new System.Windows.Forms.TextBox();
-            this.Flow6_Name_SI_CB = new System.Windows.Forms.ComboBox();
-            this.label44 = new System.Windows.Forms.Label();
-            this.label45 = new System.Windows.Forms.Label();
-            this.label46 = new System.Windows.Forms.Label();
-            this.Flow6_Modification_CB = new System.Windows.Forms.ComboBox();
-            this.label47 = new System.Windows.Forms.Label();
-            this.Flow6_ZavodskNomer_TB = new System.Windows.Forms.TextBox();
-            this.label48 = new System.Windows.Forms.Label();
-            this.Next_B = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
-            this.Rashodomer2_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer3_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer6_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer5_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer4_CB = new System.Windows.Forms.CheckBox();
-            this.Rashodomer1_GB.SuspendLayout();
-            this.Rashodomer2_GB.SuspendLayout();
-            this.Rashodomer3_GB.SuspendLayout();
-            this.Rashodomer4_GB.SuspendLayout();
-            this.Rashodomer5_GB.SuspendLayout();
-            this.Rashodomer6_GB.SuspendLayout();
-            this.SuspendLayout();
+            backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
+            label7 = new Label();
+            Flow1_Document_CB = new ComboBox();
+            Flow1_WeightImpulse_TB = new TextBox();
+            label6 = new Label();
+            label5 = new Label();
+            Flow1_Diameter_CB = new ComboBox();
+            Flow1_ZavodskNomer_TB = new TextBox();
+            label4 = new Label();
+            label3 = new Label();
+            Flow1_Modification_CB = new ComboBox();
+            label2 = new Label();
+            Flow1_Name_SI_CB = new ComboBox();
+            GosReestr = new Label();
+            Flow1_GosReestr_CB = new ComboBox();
+            label1 = new Label();
+            Rashodomer1_GB = new GroupBox();
+            label8 = new Label();
+            Rashodomer1_CB = new CheckBox();
+            Rashodomer2_GB = new GroupBox();
+            label10 = new Label();
+            Rashodomer2_CB = new CheckBox();
+            Flow2_Diameter_CB = new ComboBox();
+            label11 = new Label();
+            Flow2_GosReestr_CB = new ComboBox();
+            Flow2_Document_CB = new ComboBox();
+            label12 = new Label();
+            Flow2_WeightImpulse_TB = new TextBox();
+            Flow2_Name_SI_CB = new ComboBox();
+            label13 = new Label();
+            label14 = new Label();
+            label15 = new Label();
+            Flow2_Modification_CB = new ComboBox();
+            label16 = new Label();
+            Flow2_ZavodskNomer_TB = new TextBox();
+            label17 = new Label();
+            Rashodomer3_GB = new GroupBox();
+            label9 = new Label();
+            Rashodomer3_CB = new CheckBox();
+            Flow3_Diameter_CB = new ComboBox();
+            label18 = new Label();
+            Flow3_GosReestr_CB = new ComboBox();
+            Flow3_Document_CB = new ComboBox();
+            label19 = new Label();
+            Flow3_WeightImpulse_TB = new TextBox();
+            Flow3_Name_SI_CB = new ComboBox();
+            label20 = new Label();
+            label21 = new Label();
+            label22 = new Label();
+            Flow3_Modification_CB = new ComboBox();
+            label23 = new Label();
+            Flow3_ZavodskNomer_TB = new TextBox();
+            label24 = new Label();
+            Rashodomer4_GB = new GroupBox();
+            label25 = new Label();
+            Rashodomer4_CB = new CheckBox();
+            Flow4_Diameter_CB = new ComboBox();
+            label26 = new Label();
+            Flow4_GosReestr_CB = new ComboBox();
+            Flow4_Document_CB = new ComboBox();
+            label27 = new Label();
+            Flow4_WeightImpulse_TB = new TextBox();
+            Flow4_Name_SI_CB = new ComboBox();
+            label28 = new Label();
+            label29 = new Label();
+            label30 = new Label();
+            Flow4_Modification_CB = new ComboBox();
+            label31 = new Label();
+            Flow4_ZavodskNomer_TB = new TextBox();
+            label32 = new Label();
+            Rashodomer5_GB = new GroupBox();
+            label33 = new Label();
+            Rashodomer5_CB = new CheckBox();
+            Flow5_Diameter_CB = new ComboBox();
+            label34 = new Label();
+            Flow5_GosReestr_CB = new ComboBox();
+            Flow5_Document_CB = new ComboBox();
+            label35 = new Label();
+            Flow5_WeightImpulse_TB = new TextBox();
+            Flow5_Name_SI_CB = new ComboBox();
+            label36 = new Label();
+            label37 = new Label();
+            label38 = new Label();
+            Flow5_Modification_CB = new ComboBox();
+            label39 = new Label();
+            Flow5_ZavodskNomer_TB = new TextBox();
+            label40 = new Label();
+            Rashodomer6_GB = new GroupBox();
+            label41 = new Label();
+            Rashodomer6_CB = new CheckBox();
+            Flow6_Diameter_CB = new ComboBox();
+            label42 = new Label();
+            Flow6_GosReestr_CB = new ComboBox();
+            Flow6_Document_CB = new ComboBox();
+            label43 = new Label();
+            Flow6_WeightImpulse_TB = new TextBox();
+            Flow6_Name_SI_CB = new ComboBox();
+            label44 = new Label();
+            label45 = new Label();
+            label46 = new Label();
+            Flow6_Modification_CB = new ComboBox();
+            label47 = new Label();
+            Flow6_ZavodskNomer_TB = new TextBox();
+            label48 = new Label();
+            Next_B = new Button();
+            button1 = new Button();
+            Rashodomer1_GB.SuspendLayout();
+            Rashodomer2_GB.SuspendLayout();
+            Rashodomer3_GB.SuspendLayout();
+            Rashodomer4_GB.SuspendLayout();
+            Rashodomer5_GB.SuspendLayout();
+            Rashodomer6_GB.SuspendLayout();
+            SuspendLayout();
             // 
             // label7
             // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(20, 229);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(148, 16);
-            this.label7.TabIndex = 33;
-            this.label7.Text = "Документ на поверку";
+            label7.AutoSize = true;
+            label7.Location = new Point(18, 215);
+            label7.Margin = new Padding(4, 0, 4, 0);
+            label7.Name = "label7";
+            label7.Size = new Size(125, 15);
+            label7.TabIndex = 33;
+            label7.Text = "Документ на поверку";
             // 
             // Flow1_Document_CB
             // 
-            this.Flow1_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow1_Document_CB.FormattingEnabled = true;
-            this.Flow1_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow1_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow1_Document_CB.Name = "Flow1_Document_CB";
-            this.Flow1_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_Document_CB.TabIndex = 32;
+            Flow1_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow1_Document_CB.FormattingEnabled = true;
+            Flow1_Document_CB.Location = new Point(168, 209);
+            Flow1_Document_CB.Margin = new Padding(4);
+            Flow1_Document_CB.Name = "Flow1_Document_CB";
+            Flow1_Document_CB.Size = new Size(155, 23);
+            Flow1_Document_CB.TabIndex = 32;
             // 
             // Flow1_WeightImpulse_TB
             // 
-            this.Flow1_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow1_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow1_WeightImpulse_TB.Name = "Flow1_WeightImpulse_TB";
-            this.Flow1_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow1_WeightImpulse_TB.TabIndex = 31;
+            Flow1_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow1_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow1_WeightImpulse_TB.Name = "Flow1_WeightImpulse_TB";
+            Flow1_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow1_WeightImpulse_TB.TabIndex = 31;
             // 
             // label6
             // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(20, 199);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(97, 16);
-            this.label6.TabIndex = 30;
-            this.label6.Text = "Вес импульса";
+            label6.AutoSize = true;
+            label6.Location = new Point(18, 187);
+            label6.Margin = new Padding(4, 0, 4, 0);
+            label6.Name = "label6";
+            label6.Size = new Size(83, 15);
+            label6.TabIndex = 30;
+            label6.Text = "Вес импульса";
             // 
             // label5
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(20, 169);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(157, 16);
-            this.label5.TabIndex = 29;
-            this.label5.Text = "Номинальный диаметр";
+            label5.AutoSize = true;
+            label5.Location = new Point(18, 158);
+            label5.Margin = new Padding(4, 0, 4, 0);
+            label5.Name = "label5";
+            label5.Size = new Size(137, 15);
+            label5.TabIndex = 29;
+            label5.Text = "Номинальный диаметр";
             // 
             // Flow1_Diameter_CB
             // 
-            this.Flow1_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow1_Diameter_CB.FormattingEnabled = true;
-            this.Flow1_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow1_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow1_Diameter_CB.Name = "Flow1_Diameter_CB";
-            this.Flow1_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_Diameter_CB.TabIndex = 28;
+            Flow1_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow1_Diameter_CB.FormattingEnabled = true;
+            Flow1_Diameter_CB.Location = new Point(168, 152);
+            Flow1_Diameter_CB.Margin = new Padding(4);
+            Flow1_Diameter_CB.Name = "Flow1_Diameter_CB";
+            Flow1_Diameter_CB.Size = new Size(155, 23);
+            Flow1_Diameter_CB.TabIndex = 28;
             // 
             // Flow1_ZavodskNomer_TB
             // 
-            this.Flow1_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow1_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow1_ZavodskNomer_TB.Name = "Flow1_ZavodskNomer_TB";
-            this.Flow1_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow1_ZavodskNomer_TB.TabIndex = 27;
+            Flow1_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow1_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow1_ZavodskNomer_TB.Name = "Flow1_ZavodskNomer_TB";
+            Flow1_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow1_ZavodskNomer_TB.TabIndex = 27;
             // 
             // label4
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(20, 139);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(122, 16);
-            this.label4.TabIndex = 26;
-            this.label4.Text = "Заводской номер";
+            label4.AutoSize = true;
+            label4.Location = new Point(18, 130);
+            label4.Margin = new Padding(4, 0, 4, 0);
+            label4.Name = "label4";
+            label4.Size = new Size(104, 15);
+            label4.TabIndex = 26;
+            label4.Text = "Заводской номер";
             // 
             // label3
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(20, 107);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(99, 16);
-            this.label3.TabIndex = 25;
-            this.label3.Text = "Модификация";
+            label3.AutoSize = true;
+            label3.Location = new Point(18, 100);
+            label3.Margin = new Padding(4, 0, 4, 0);
+            label3.Name = "label3";
+            label3.Size = new Size(86, 15);
+            label3.TabIndex = 25;
+            label3.Text = "Модификация";
             // 
             // Flow1_Modification_CB
             // 
-            this.Flow1_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow1_Modification_CB.FormattingEnabled = true;
-            this.Flow1_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow1_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow1_Modification_CB.Name = "Flow1_Modification_CB";
-            this.Flow1_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_Modification_CB.TabIndex = 24;
+            Flow1_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow1_Modification_CB.FormattingEnabled = true;
+            Flow1_Modification_CB.Location = new Point(168, 96);
+            Flow1_Modification_CB.Margin = new Padding(4);
+            Flow1_Modification_CB.Name = "Flow1_Modification_CB";
+            Flow1_Modification_CB.Size = new Size(155, 23);
+            Flow1_Modification_CB.TabIndex = 24;
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(20, 43);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(32, 16);
-            this.label2.TabIndex = 21;
-            this.label2.Text = "Тип";
+            label2.AutoSize = true;
+            label2.Location = new Point(18, 40);
+            label2.Margin = new Padding(4, 0, 4, 0);
+            label2.Name = "label2";
+            label2.Size = new Size(28, 15);
+            label2.TabIndex = 21;
+            label2.Text = "Тип";
             // 
             // Flow1_Name_SI_CB
-            //
-            this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow1_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow1_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow1_Name_SI_CB.FormattingEnabled = true;
-            this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow1_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow1_Name_SI_CB.Name = "Flow1_Name_SI_CB";
-            this.Flow1_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_Name_SI_CB.TabIndex = 20;
-            this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
-            this.Flow1_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow1_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow1_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
+            // 
+            Flow1_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1_Name_SI_CB.Location = new Point(168, 38);
+            Flow1_Name_SI_CB.Margin = new Padding(4);
+            Flow1_Name_SI_CB.Name = "Flow1_Name_SI_CB";
+            Flow1_Name_SI_CB.Size = new Size(155, 23);
+            Flow1_Name_SI_CB.TabIndex = 20;
+            Flow1_Name_SI_CB.SelectedIndexChanged += Flow1_Name_SI_CB_SelectedIndexChanged;
+            Flow1_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow1_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow1_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
             // 
             // GosReestr
             // 
-            this.GosReestr.AutoSize = true;
-            this.GosReestr.Location = new System.Drawing.Point(20, 75);
-            this.GosReestr.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.GosReestr.Name = "GosReestr";
-            this.GosReestr.Size = new System.Drawing.Size(111, 16);
-            this.GosReestr.TabIndex = 23;
-            this.GosReestr.Text = "Производитель";
+            GosReestr.AutoSize = true;
+            GosReestr.Location = new Point(18, 70);
+            GosReestr.Margin = new Padding(4, 0, 4, 0);
+            GosReestr.Name = "GosReestr";
+            GosReestr.Size = new Size(92, 15);
+            GosReestr.TabIndex = 23;
+            GosReestr.Text = "Производитель";
             // 
             // Flow1_GosReestr_CB
             // 
-            this.Flow1_GosReestr_CB.AllowDrop = true;
-            this.Flow1_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow1_GosReestr_CB.FormattingEnabled = true;
-            this.Flow1_GosReestr_CB.IntegralHeight = false;
-            this.Flow1_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow1_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow1_GosReestr_CB.Name = "Flow1_GosReestr_CB";
-            this.Flow1_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_GosReestr_CB.TabIndex = 22;
-            this.Flow1_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.GosReestrCB_SelectedIndexChanged);
+            Flow1_GosReestr_CB.AllowDrop = true;
+            Flow1_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow1_GosReestr_CB.FormattingEnabled = true;
+            Flow1_GosReestr_CB.IntegralHeight = false;
+            Flow1_GosReestr_CB.Location = new Point(168, 67);
+            Flow1_GosReestr_CB.Margin = new Padding(4);
+            Flow1_GosReestr_CB.Name = "Flow1_GosReestr_CB";
+            Flow1_GosReestr_CB.Size = new Size(155, 23);
+            Flow1_GosReestr_CB.TabIndex = 22;
+            Flow1_GosReestr_CB.SelectedIndexChanged += GosReestrCB_SelectedIndexChanged;
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label1.Location = new System.Drawing.Point(220, 23);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(899, 39);
-            this.label1.TabIndex = 19;
-            this.label1.Text = "Настройка параметров поверяемых преобразователей";
+            label1.AutoSize = true;
+            label1.Font = new Font("Microsoft Sans Serif", 20F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label1.Location = new Point(192, 22);
+            label1.Margin = new Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new Size(710, 31);
+            label1.TabIndex = 19;
+            label1.Text = "Настройка параметров поверяемых преобразователей";
             // 
             // Rashodomer1_GB
             // 
-            this.Rashodomer1_GB.Controls.Add(this.label8);
-            this.Rashodomer1_GB.Controls.Add(this.Rashodomer1_CB);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_Diameter_CB);
-            this.Rashodomer1_GB.Controls.Add(this.label7);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_GosReestr_CB);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_Document_CB);
-            this.Rashodomer1_GB.Controls.Add(this.GosReestr);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_WeightImpulse_TB);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_Name_SI_CB);
-            this.Rashodomer1_GB.Controls.Add(this.label6);
-            this.Rashodomer1_GB.Controls.Add(this.label2);
-            this.Rashodomer1_GB.Controls.Add(this.label5);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_Modification_CB);
-            this.Rashodomer1_GB.Controls.Add(this.label3);
-            this.Rashodomer1_GB.Controls.Add(this.Flow1_ZavodskNomer_TB);
-            this.Rashodomer1_GB.Controls.Add(this.label4);
-            this.Rashodomer1_GB.Enabled = true;
-            this.Rashodomer1_GB.Location = new System.Drawing.Point(68, 60);
-            this.Rashodomer1_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer1_GB.Name = "Rashodomer1_GB";
-            this.Rashodomer1_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer1_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer1_GB.TabIndex = 34;
-            this.Rashodomer1_GB.TabStop = false;
-            this.Rashodomer1_GB.Tag = "FirstFlowmeter";
+            Rashodomer1_GB.Controls.Add(label8);
+            Rashodomer1_GB.Controls.Add(Rashodomer1_CB);
+            Rashodomer1_GB.Controls.Add(Flow1_Diameter_CB);
+            Rashodomer1_GB.Controls.Add(label7);
+            Rashodomer1_GB.Controls.Add(Flow1_GosReestr_CB);
+            Rashodomer1_GB.Controls.Add(Flow1_Document_CB);
+            Rashodomer1_GB.Controls.Add(GosReestr);
+            Rashodomer1_GB.Controls.Add(Flow1_WeightImpulse_TB);
+            Rashodomer1_GB.Controls.Add(Flow1_Name_SI_CB);
+            Rashodomer1_GB.Controls.Add(label6);
+            Rashodomer1_GB.Controls.Add(label2);
+            Rashodomer1_GB.Controls.Add(label5);
+            Rashodomer1_GB.Controls.Add(Flow1_Modification_CB);
+            Rashodomer1_GB.Controls.Add(label3);
+            Rashodomer1_GB.Controls.Add(Flow1_ZavodskNomer_TB);
+            Rashodomer1_GB.Controls.Add(label4);
+            Rashodomer1_GB.Location = new Point(60, 56);
+            Rashodomer1_GB.Margin = new Padding(4);
+            Rashodomer1_GB.Name = "Rashodomer1_GB";
+            Rashodomer1_GB.Padding = new Padding(4);
+            Rashodomer1_GB.Size = new Size(342, 281);
+            Rashodomer1_GB.TabIndex = 34;
+            Rashodomer1_GB.TabStop = false;
+            Rashodomer1_GB.Tag = "FirstFlowmeter";
             // 
             // label8
             // 
-            this.label8.AutoSize = true;
-            this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label8.Location = new System.Drawing.Point(20, 0);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(195, 29);
-            this.label8.TabIndex = 35;
-            this.label8.Text = "Расходомер №1";
+            label8.AutoSize = true;
+            label8.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label8.Location = new Point(18, 0);
+            label8.Margin = new Padding(4, 0, 4, 0);
+            label8.Name = "label8";
+            label8.Size = new Size(156, 24);
+            label8.TabIndex = 35;
+            label8.Text = "Расходомер №1";
             // 
             // Rashodomer1_CB
             // 
-            this.Rashodomer1_CB.AutoSize = true;
-            this.Rashodomer1_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer1_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer1_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer1_CB.Name = "Rashodomer1_CB";
-            this.Rashodomer1_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer1_CB.TabIndex = 36;
-            this.Rashodomer1_CB.Text = "Установлен";
-            this.Rashodomer1_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer1_CB.CheckedChanged += new System.EventHandler(this.Rashodomer1_CB_CheckedChanged);
+            Rashodomer1_CB.AutoSize = true;
+            Rashodomer1_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer1_CB.Location = new Point(228, 0);
+            Rashodomer1_CB.Margin = new Padding(4);
+            Rashodomer1_CB.Name = "Rashodomer1_CB";
+            Rashodomer1_CB.Size = new Size(97, 17);
+            Rashodomer1_CB.TabIndex = 36;
+            Rashodomer1_CB.Text = "Установлен";
+            Rashodomer1_CB.UseVisualStyleBackColor = true;
+            Rashodomer1_CB.CheckedChanged += Rashodomer1_CB_CheckedChanged;
             // 
             // Rashodomer2_GB
             // 
-            this.Rashodomer2_GB.Controls.Add(this.label10);
-            this.Rashodomer2_GB.Controls.Add(this.Rashodomer2_CB);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_Diameter_CB);
-            this.Rashodomer2_GB.Controls.Add(this.label11);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_GosReestr_CB);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_Document_CB);
-            this.Rashodomer2_GB.Controls.Add(this.label12);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_WeightImpulse_TB);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_Name_SI_CB);
-            this.Rashodomer2_GB.Controls.Add(this.label13);
-            this.Rashodomer2_GB.Controls.Add(this.label14);
-            this.Rashodomer2_GB.Controls.Add(this.label15);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_Modification_CB);
-            this.Rashodomer2_GB.Controls.Add(this.label16);
-            this.Rashodomer2_GB.Controls.Add(this.Flow2_ZavodskNomer_TB);
-            this.Rashodomer2_GB.Controls.Add(this.label17);
-            this.Rashodomer2_GB.Enabled = true;
-            this.Rashodomer2_GB.Location = new System.Drawing.Point(68, 369);
-            this.Rashodomer2_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer2_GB.Name = "Rashodomer2_GB";
-            this.Rashodomer2_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer2_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer2_GB.TabIndex = 36;
-            this.Rashodomer2_GB.TabStop = false;
-            this.Rashodomer2_GB.Tag = "FirstFlowmeter";
+            Rashodomer2_GB.Controls.Add(label10);
+            Rashodomer2_GB.Controls.Add(Rashodomer2_CB);
+            Rashodomer2_GB.Controls.Add(Flow2_Diameter_CB);
+            Rashodomer2_GB.Controls.Add(label11);
+            Rashodomer2_GB.Controls.Add(Flow2_GosReestr_CB);
+            Rashodomer2_GB.Controls.Add(Flow2_Document_CB);
+            Rashodomer2_GB.Controls.Add(label12);
+            Rashodomer2_GB.Controls.Add(Flow2_WeightImpulse_TB);
+            Rashodomer2_GB.Controls.Add(Flow2_Name_SI_CB);
+            Rashodomer2_GB.Controls.Add(label13);
+            Rashodomer2_GB.Controls.Add(label14);
+            Rashodomer2_GB.Controls.Add(label15);
+            Rashodomer2_GB.Controls.Add(Flow2_Modification_CB);
+            Rashodomer2_GB.Controls.Add(label16);
+            Rashodomer2_GB.Controls.Add(Flow2_ZavodskNomer_TB);
+            Rashodomer2_GB.Controls.Add(label17);
+            Rashodomer2_GB.Location = new Point(60, 346);
+            Rashodomer2_GB.Margin = new Padding(4);
+            Rashodomer2_GB.Name = "Rashodomer2_GB";
+            Rashodomer2_GB.Padding = new Padding(4);
+            Rashodomer2_GB.Size = new Size(342, 281);
+            Rashodomer2_GB.TabIndex = 36;
+            Rashodomer2_GB.TabStop = false;
+            Rashodomer2_GB.Tag = "FirstFlowmeter";
             // 
             // label10
             // 
-            this.label10.AutoSize = true;
-            this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label10.Location = new System.Drawing.Point(20, 0);
-            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(195, 29);
-            this.label10.TabIndex = 35;
-            this.label10.Text = "Расходомер №2";
-            // 
-            // Flow2_Diameter_CB
-            // 
-            this.Flow2_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow2_Diameter_CB.FormattingEnabled = true;
-            this.Flow2_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow2_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow2_Diameter_CB.Name = "Flow2_Diameter_CB";
-            this.Flow2_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_Diameter_CB.TabIndex = 28;
-            // 
-            // label11
-            // 
-            this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(20, 229);
-            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(148, 16);
-            this.label11.TabIndex = 33;
-            this.label11.Text = "Документ на поверку";
-            // 
-            // Flow2_GosReestr_CB
-            // 
-            this.Flow2_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow2_GosReestr_CB.FormattingEnabled = true;
-            this.Flow2_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow2_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow2_GosReestr_CB.Name = "Flow2_GosReestr_CB";
-            this.Flow2_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_GosReestr_CB.TabIndex = 22;
-            this.Flow2_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow2_GosReestr_CB_SelectedIndexChanged);
-            // 
-            // Flow2_Document_CB
-            // 
-            this.Flow2_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow2_Document_CB.FormattingEnabled = true;
-            this.Flow2_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow2_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow2_Document_CB.Name = "Flow2_Document_CB";
-            this.Flow2_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_Document_CB.TabIndex = 32;
-            // 
-            // label12
-            //
-            this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(20, 75);
-            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(111, 16);
-            this.label12.TabIndex = 23;
-            this.label12.Text = "Производитель";
-            // 
-            // Flow2_WeightImpulse_TB
-            // 
-            this.Flow2_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow2_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow2_WeightImpulse_TB.Name = "Flow2_WeightImpulse_TB";
-            this.Flow2_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow2_WeightImpulse_TB.TabIndex = 31;
-            // 
-            // Flow2_Name_SI_CB
-            // 
-            this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow2_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow2_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow2_Name_SI_CB.FormattingEnabled = true;
-            this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow2_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
-            this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_Name_SI_CB.TabIndex = 20;
-            this.Flow2_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow2_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow2_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
-            // 
-            // label13
-            // 
-            this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(20, 199);
-            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(97, 16);
-            this.label13.TabIndex = 30;
-            this.label13.Text = "Вес импульса";
-            // 
-            // label14
-            // 
-            this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(20, 43);
-            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(32, 16);
-            this.label14.TabIndex = 21;
-            this.label14.Text = "Тип";
-            this.label14.Click += new System.EventHandler(this.label14_Click);
-            // 
-            // label15
-            // 
-            this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(20, 169);
-            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(157, 16);
-            this.label15.TabIndex = 29;
-            this.label15.Text = "Номинальный диаметр";
-            // 
-            // Flow2_Modification_CB
-            // 
-            this.Flow2_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow2_Modification_CB.FormattingEnabled = true;
-            this.Flow2_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow2_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow2_Modification_CB.Name = "Flow2_Modification_CB";
-            this.Flow2_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_Modification_CB.TabIndex = 24;
-            // 
-            // label16
-            // 
-            this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(20, 107);
-            this.label16.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(99, 16);
-            this.label16.TabIndex = 25;
-            this.label16.Text = "Модификация";
-            // 
-            // Flow2_ZavodskNomer_TB
-            // 
-            this.Flow2_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow2_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow2_ZavodskNomer_TB.Name = "Flow2_ZavodskNomer_TB";
-            this.Flow2_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow2_ZavodskNomer_TB.TabIndex = 27;
-            // 
-            // label17
-            // 
-            this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(20, 139);
-            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(122, 16);
-            this.label17.TabIndex = 26;
-            this.label17.Text = "Заводской номер";
-            // 
-            // Rashodomer3_GB
-            // 
-            this.Rashodomer3_GB.Controls.Add(this.label9);
-            this.Rashodomer3_GB.Controls.Add(this.Rashodomer3_CB);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_Diameter_CB);
-            this.Rashodomer3_GB.Controls.Add(this.label18);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_GosReestr_CB);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_Document_CB);
-            this.Rashodomer3_GB.Controls.Add(this.label19);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_WeightImpulse_TB);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_Name_SI_CB);
-            this.Rashodomer3_GB.Controls.Add(this.label20);
-            this.Rashodomer3_GB.Controls.Add(this.label21);
-            this.Rashodomer3_GB.Controls.Add(this.label22);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_Modification_CB);
-            this.Rashodomer3_GB.Controls.Add(this.label23);
-            this.Rashodomer3_GB.Controls.Add(this.Flow3_ZavodskNomer_TB);
-            this.Rashodomer3_GB.Controls.Add(this.label24);
-            this.Rashodomer3_GB.Enabled = true;
-            this.Rashodomer3_GB.Location = new System.Drawing.Point(467, 60);
-            this.Rashodomer3_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer3_GB.Name = "Rashodomer3_GB";
-            this.Rashodomer3_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer3_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer3_GB.TabIndex = 37;
-            this.Rashodomer3_GB.TabStop = false;
-            this.Rashodomer3_GB.Tag = "FirstFlowmeter";
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label9.Location = new System.Drawing.Point(20, 0);
-            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(195, 29);
-            this.label9.TabIndex = 35;
-            this.label9.Text = "Расходомер №3";
-            // 
-            // Flow3_Diameter_CB
-            // 
-            this.Flow3_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow3_Diameter_CB.FormattingEnabled = true;
-            this.Flow3_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow3_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow3_Diameter_CB.Name = "Flow3_Diameter_CB";
-            this.Flow3_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_Diameter_CB.TabIndex = 28;
-            // 
-            // label18
-            // 
-            this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(20, 229);
-            this.label18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(148, 16);
-            this.label18.TabIndex = 33;
-            this.label18.Text = "Документ на поверку";
-            // 
-            // Flow3_GosReestr_CB
-            // 
-            this.Flow3_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow3_GosReestr_CB.FormattingEnabled = true;
-            this.Flow3_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow3_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow3_GosReestr_CB.Name = "Flow3_GosReestr_CB";
-            this.Flow3_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_GosReestr_CB.TabIndex = 22;
-            this.Flow3_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow3_GosReestr_CB_SelectedIndexChanged);
-            // 
-            // Flow3_Document_CB
-            // 
-            this.Flow3_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow3_Document_CB.FormattingEnabled = true;
-            this.Flow3_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow3_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow3_Document_CB.Name = "Flow3_Document_CB";
-            this.Flow3_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_Document_CB.TabIndex = 32;
-            // 
-            // label19
-            //
-            this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(20, 75);
-            this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(111, 16);
-            this.label19.TabIndex = 23;
-            this.label19.Text = "Производитель";
-            // 
-            // Flow3_WeightImpulse_TB
-            // 
-            this.Flow3_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow3_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow3_WeightImpulse_TB.Name = "Flow3_WeightImpulse_TB";
-            this.Flow3_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow3_WeightImpulse_TB.TabIndex = 31;
-            // 
-            // Flow3_Name_SI_CB
-            // 
-            this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow3_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow3_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow3_Name_SI_CB.FormattingEnabled = true;
-            this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow3_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
-            this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_Name_SI_CB.TabIndex = 20;
-            this.Flow3_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow3_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow3_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
-            // 
-            // label20
-            // 
-            this.label20.AutoSize = true;
-            this.label20.Location = new System.Drawing.Point(20, 199);
-            this.label20.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(97, 16);
-            this.label20.TabIndex = 30;
-            this.label20.Text = "Вес импульса";
-            // 
-            // label21
-            // 
-            this.label21.AutoSize = true;
-            this.label21.Location = new System.Drawing.Point(20, 43);
-            this.label21.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label21.Name = "label21";
-            this.label21.Size = new System.Drawing.Size(32, 16);
-            this.label21.TabIndex = 21;
-            this.label21.Text = "Тип";
-            // 
-            // label22
-            // 
-            this.label22.AutoSize = true;
-            this.label22.Location = new System.Drawing.Point(20, 169);
-            this.label22.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(157, 16);
-            this.label22.TabIndex = 29;
-            this.label22.Text = "Номинальный диаметр";
-            // 
-            // Flow3_Modification_CB
-            // 
-            this.Flow3_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow3_Modification_CB.FormattingEnabled = true;
-            this.Flow3_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow3_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow3_Modification_CB.Name = "Flow3_Modification_CB";
-            this.Flow3_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_Modification_CB.TabIndex = 24;
-            // 
-            // label23
-            // 
-            this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(20, 107);
-            this.label23.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(99, 16);
-            this.label23.TabIndex = 25;
-            this.label23.Text = "Модификация";
-            // 
-            // Flow3_ZavodskNomer_TB
-            // 
-            this.Flow3_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow3_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow3_ZavodskNomer_TB.Name = "Flow3_ZavodskNomer_TB";
-            this.Flow3_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow3_ZavodskNomer_TB.TabIndex = 27;
-            // 
-            // label24
-            // 
-            this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(20, 139);
-            this.label24.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(122, 16);
-            this.label24.TabIndex = 26;
-            this.label24.Text = "Заводской номер";
-            // 
-            // Rashodomer4_GB
-            // 
-            this.Rashodomer4_GB.Controls.Add(this.label25);
-            this.Rashodomer4_GB.Controls.Add(this.Rashodomer4_CB);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_Diameter_CB);
-            this.Rashodomer4_GB.Controls.Add(this.label26);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_GosReestr_CB);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_Document_CB);
-            this.Rashodomer4_GB.Controls.Add(this.label27);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_WeightImpulse_TB);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_Name_SI_CB);
-            this.Rashodomer4_GB.Controls.Add(this.label28);
-            this.Rashodomer4_GB.Controls.Add(this.label29);
-            this.Rashodomer4_GB.Controls.Add(this.label30);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_Modification_CB);
-            this.Rashodomer4_GB.Controls.Add(this.label31);
-            this.Rashodomer4_GB.Controls.Add(this.Flow4_ZavodskNomer_TB);
-            this.Rashodomer4_GB.Controls.Add(this.label32);
-            this.Rashodomer4_GB.Enabled = true;
-            this.Rashodomer4_GB.Location = new System.Drawing.Point(467, 369);
-            this.Rashodomer4_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer4_GB.Name = "Rashodomer4_GB";
-            this.Rashodomer4_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer4_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer4_GB.TabIndex = 38;
-            this.Rashodomer4_GB.TabStop = false;
-            this.Rashodomer4_GB.Tag = "FirstFlowmeter";
-            // 
-            // label25
-            // 
-            this.label25.AutoSize = true;
-            this.label25.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label25.Location = new System.Drawing.Point(20, 0);
-            this.label25.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(195, 29);
-            this.label25.TabIndex = 35;
-            this.label25.Text = "Расходомер №4";
-            // 
-            // Flow4_Diameter_CB
-            // 
-            this.Flow4_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow4_Diameter_CB.FormattingEnabled = true;
-            this.Flow4_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow4_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow4_Diameter_CB.Name = "Flow4_Diameter_CB";
-            this.Flow4_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_Diameter_CB.TabIndex = 28;
-            // 
-            // label26
-            // 
-            this.label26.AutoSize = true;
-            this.label26.Location = new System.Drawing.Point(20, 229);
-            this.label26.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(148, 16);
-            this.label26.TabIndex = 33;
-            this.label26.Text = "Документ на поверку";
-            // 
-            // Flow4_GosReestr_CB
-            //
-            this.Flow4_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow4_GosReestr_CB.FormattingEnabled = true;
-            this.Flow4_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow4_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow4_GosReestr_CB.Name = "Flow4_GosReestr_CB";
-            this.Flow4_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_GosReestr_CB.TabIndex = 22;
-            this.Flow4_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow4_GosReestr_CB_SelectedIndexChanged);
-            // 
-            // Flow4_Document_CB
-            // 
-            this.Flow4_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow4_Document_CB.FormattingEnabled = true;
-            this.Flow4_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow4_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow4_Document_CB.Name = "Flow4_Document_CB";
-            this.Flow4_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_Document_CB.TabIndex = 32;
-            // 
-            // label27
-            // 
-            this.label27.AutoSize = true;
-            this.label27.Location = new System.Drawing.Point(20, 75);
-            this.label27.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(111, 16);
-            this.label27.TabIndex = 23;
-            this.label27.Text = "Производитель";
-            // 
-            // Flow4_WeightImpulse_TB
-            // 
-            this.Flow4_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow4_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow4_WeightImpulse_TB.Name = "Flow4_WeightImpulse_TB";
-            this.Flow4_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow4_WeightImpulse_TB.TabIndex = 31;
-            // 
-            // Flow4_Name_SI_CB
-            // 
-            this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow4_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow4_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow4_Name_SI_CB.FormattingEnabled = true;
-            this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow4_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
-            this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_Name_SI_CB.TabIndex = 20;
-            this.Flow4_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow4_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow4_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
-            // 
-            // label28
-            // 
-            this.label28.AutoSize = true;
-            this.label28.Location = new System.Drawing.Point(20, 199);
-            this.label28.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label28.Name = "label28";
-            this.label28.Size = new System.Drawing.Size(97, 16);
-            this.label28.TabIndex = 30;
-            this.label28.Text = "Вес импульса";
-            // 
-            // label29
-            // 
-            this.label29.AutoSize = true;
-            this.label29.Location = new System.Drawing.Point(20, 43);
-            this.label29.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(136, 16);
-            this.label29.TabIndex = 21;
-            this.label29.Text = "Наиименование СИ";
-            // 
-            // label30
-            // 
-            this.label30.AutoSize = true;
-            this.label30.Location = new System.Drawing.Point(20, 169);
-            this.label30.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label30.Name = "label30";
-            this.label30.Size = new System.Drawing.Size(157, 16);
-            this.label30.TabIndex = 29;
-            this.label30.Text = "Номинальный диаметр";
-            // 
-            // Flow4_Modification_CB
-            // 
-            this.Flow4_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow4_Modification_CB.FormattingEnabled = true;
-            this.Flow4_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow4_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow4_Modification_CB.Name = "Flow4_Modification_CB";
-            this.Flow4_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_Modification_CB.TabIndex = 24;
-            // 
-            // label31
-            // 
-            this.label31.AutoSize = true;
-            this.label31.Location = new System.Drawing.Point(20, 107);
-            this.label31.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(99, 16);
-            this.label31.TabIndex = 25;
-            this.label31.Text = "Модификация";
-            // 
-            // Flow4_ZavodskNomer_TB
-            // 
-            this.Flow4_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow4_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow4_ZavodskNomer_TB.Name = "Flow4_ZavodskNomer_TB";
-            this.Flow4_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow4_ZavodskNomer_TB.TabIndex = 27;
-            // 
-            // label32
-            // 
-            this.label32.AutoSize = true;
-            this.label32.Location = new System.Drawing.Point(20, 139);
-            this.label32.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(122, 16);
-            this.label32.TabIndex = 26;
-            this.label32.Text = "Заводской номер";
-            // 
-            // Rashodomer5_GB
-            // 
-            this.Rashodomer5_GB.Controls.Add(this.label33);
-            this.Rashodomer5_GB.Controls.Add(this.Rashodomer5_CB);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_Diameter_CB);
-            this.Rashodomer5_GB.Controls.Add(this.label34);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_GosReestr_CB);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_Document_CB);
-            this.Rashodomer5_GB.Controls.Add(this.label35);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_WeightImpulse_TB);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_Name_SI_CB);
-            this.Rashodomer5_GB.Controls.Add(this.label36);
-            this.Rashodomer5_GB.Controls.Add(this.label37);
-            this.Rashodomer5_GB.Controls.Add(this.label38);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_Modification_CB);
-            this.Rashodomer5_GB.Controls.Add(this.label39);
-            this.Rashodomer5_GB.Controls.Add(this.Flow5_ZavodskNomer_TB);
-            this.Rashodomer5_GB.Controls.Add(this.label40);
-            this.Rashodomer5_GB.Enabled = true;
-            this.Rashodomer5_GB.Location = new System.Drawing.Point(865, 60);
-            this.Rashodomer5_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer5_GB.Name = "Rashodomer5_GB";
-            this.Rashodomer5_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer5_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer5_GB.TabIndex = 37;
-            this.Rashodomer5_GB.TabStop = false;
-            this.Rashodomer5_GB.Tag = "FirstFlowmeter";
-            // 
-            // label33
-            // 
-            this.label33.AutoSize = true;
-            this.label33.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label33.Location = new System.Drawing.Point(20, 0);
-            this.label33.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(195, 29);
-            this.label33.TabIndex = 35;
-            this.label33.Text = "Расходомер №5";
-            // 
-            // Flow5_Diameter_CB
-            // 
-            this.Flow5_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow5_Diameter_CB.FormattingEnabled = true;
-            this.Flow5_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow5_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow5_Diameter_CB.Name = "Flow5_Diameter_CB";
-            this.Flow5_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_Diameter_CB.TabIndex = 28;
-            // 
-            // label34
-            // 
-            this.label34.AutoSize = true;
-            this.label34.Location = new System.Drawing.Point(20, 229);
-            this.label34.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label34.Name = "label34";
-            this.label34.Size = new System.Drawing.Size(148, 16);
-            this.label34.TabIndex = 33;
-            this.label34.Text = "Документ на поверку";
-            // 
-            // Flow5_GosReestr_CB
-            //
-            this.Flow5_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow5_GosReestr_CB.FormattingEnabled = true;
-            this.Flow5_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow5_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow5_GosReestr_CB.Name = "Flow5_GosReestr_CB";
-            this.Flow5_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_GosReestr_CB.TabIndex = 22;
-            this.Flow5_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow5_GosReestr_CB_SelectedIndexChanged);
-            // 
-            // Flow5_Document_CB
-            // 
-            this.Flow5_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow5_Document_CB.FormattingEnabled = true;
-            this.Flow5_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow5_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow5_Document_CB.Name = "Flow5_Document_CB";
-            this.Flow5_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_Document_CB.TabIndex = 32;
-            // 
-            // label35
-            // 
-            this.label35.AutoSize = true;
-            this.label35.Location = new System.Drawing.Point(20, 75);
-            this.label35.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label35.Name = "label35";
-            this.label35.Size = new System.Drawing.Size(111, 16);
-            this.label35.TabIndex = 23;
-            this.label35.Text = "Производитель";
-            // 
-            // Flow5_WeightImpulse_TB
-            // 
-            this.Flow5_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow5_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow5_WeightImpulse_TB.Name = "Flow5_WeightImpulse_TB";
-            this.Flow5_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow5_WeightImpulse_TB.TabIndex = 31;
-            // 
-            // Flow5_Name_SI_CB
-            // 
-            this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow5_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow5_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow5_Name_SI_CB.FormattingEnabled = true;
-            this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow5_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
-            this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_Name_SI_CB.TabIndex = 20;
-            this.Flow5_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow5_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow5_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
-            // 
-            // label36
-            // 
-            this.label36.AutoSize = true;
-            this.label36.Location = new System.Drawing.Point(20, 199);
-            this.label36.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label36.Name = "label36";
-            this.label36.Size = new System.Drawing.Size(97, 16);
-            this.label36.TabIndex = 30;
-            this.label36.Text = "Вес импульса";
-            // 
-            // label37
-            // 
-            this.label37.AutoSize = true;
-            this.label37.Location = new System.Drawing.Point(20, 43);
-            this.label37.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label37.Name = "label37";
-            this.label37.Size = new System.Drawing.Size(32, 16);
-            this.label37.TabIndex = 21;
-            this.label37.Text = "Тип";
-            // 
-            // label38
-            // 
-            this.label38.AutoSize = true;
-            this.label38.Location = new System.Drawing.Point(20, 169);
-            this.label38.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label38.Name = "label38";
-            this.label38.Size = new System.Drawing.Size(157, 16);
-            this.label38.TabIndex = 29;
-            this.label38.Text = "Номинальный диаметр";
-            // 
-            // Flow5_Modification_CB
-            // 
-            this.Flow5_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow5_Modification_CB.FormattingEnabled = true;
-            this.Flow5_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow5_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow5_Modification_CB.Name = "Flow5_Modification_CB";
-            this.Flow5_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_Modification_CB.TabIndex = 24;
-            // 
-            // label39
-            // 
-            this.label39.AutoSize = true;
-            this.label39.Location = new System.Drawing.Point(20, 107);
-            this.label39.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label39.Name = "label39";
-            this.label39.Size = new System.Drawing.Size(99, 16);
-            this.label39.TabIndex = 25;
-            this.label39.Text = "Модификация";
-            // 
-            // Flow5_ZavodskNomer_TB
-            // 
-            this.Flow5_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow5_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow5_ZavodskNomer_TB.Name = "Flow5_ZavodskNomer_TB";
-            this.Flow5_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow5_ZavodskNomer_TB.TabIndex = 27;
-            // 
-            // label40
-            // 
-            this.label40.AutoSize = true;
-            this.label40.Location = new System.Drawing.Point(20, 139);
-            this.label40.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label40.Name = "label40";
-            this.label40.Size = new System.Drawing.Size(122, 16);
-            this.label40.TabIndex = 26;
-            this.label40.Text = "Заводской номер";
-            // 
-            // Rashodomer6_GB
-            // 
-            this.Rashodomer6_GB.Controls.Add(this.label41);
-            this.Rashodomer6_GB.Controls.Add(this.Rashodomer6_CB);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_Diameter_CB);
-            this.Rashodomer6_GB.Controls.Add(this.label42);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_GosReestr_CB);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_Document_CB);
-            this.Rashodomer6_GB.Controls.Add(this.label43);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_WeightImpulse_TB);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_Name_SI_CB);
-            this.Rashodomer6_GB.Controls.Add(this.label44);
-            this.Rashodomer6_GB.Controls.Add(this.label45);
-            this.Rashodomer6_GB.Controls.Add(this.label46);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_Modification_CB);
-            this.Rashodomer6_GB.Controls.Add(this.label47);
-            this.Rashodomer6_GB.Controls.Add(this.Flow6_ZavodskNomer_TB);
-            this.Rashodomer6_GB.Controls.Add(this.label48);
-            this.Rashodomer6_GB.Enabled = true;
-            this.Rashodomer6_GB.Location = new System.Drawing.Point(865, 369);
-            this.Rashodomer6_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer6_GB.Name = "Rashodomer6_GB";
-            this.Rashodomer6_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer6_GB.Size = new System.Drawing.Size(391, 300);
-            this.Rashodomer6_GB.TabIndex = 37;
-            this.Rashodomer6_GB.TabStop = false;
-            this.Rashodomer6_GB.Tag = "FirstFlowmeter";
-            this.Rashodomer6_GB.Enter += new System.EventHandler(this.groupBox6_Enter);
-            // 
-            // label41
-            // 
-            this.label41.AutoSize = true;
-            this.label41.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label41.Location = new System.Drawing.Point(20, 0);
-            this.label41.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label41.Name = "label41";
-            this.label41.Size = new System.Drawing.Size(195, 29);
-            this.label41.TabIndex = 35;
-            this.label41.Text = "Расходомер №6";
-            // 
-            // Flow6_Diameter_CB
-            // 
-            this.Flow6_Diameter_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow6_Diameter_CB.FormattingEnabled = true;
-            this.Flow6_Diameter_CB.Location = new System.Drawing.Point(192, 162);
-            this.Flow6_Diameter_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow6_Diameter_CB.Name = "Flow6_Diameter_CB";
-            this.Flow6_Diameter_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_Diameter_CB.TabIndex = 28;
-            // 
-            // label42
-            // 
-            this.label42.AutoSize = true;
-            this.label42.Location = new System.Drawing.Point(20, 229);
-            this.label42.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label42.Name = "label42";
-            this.label42.Size = new System.Drawing.Size(148, 16);
-            this.label42.TabIndex = 33;
-            this.label42.Text = "Документ на поверку";
-            // 
-            // Flow6_GosReestr_CB
-            //
-            this.Flow6_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow6_GosReestr_CB.FormattingEnabled = true;
-            this.Flow6_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
-            this.Flow6_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow6_GosReestr_CB.Name = "Flow6_GosReestr_CB";
-            this.Flow6_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_GosReestr_CB.TabIndex = 22;
-            this.Flow6_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow6_GosReestr_CB_SelectedIndexChanged);
-            // 
-            // Flow6_Document_CB
-            // 
-            this.Flow6_Document_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow6_Document_CB.FormattingEnabled = true;
-            this.Flow6_Document_CB.Location = new System.Drawing.Point(192, 223);
-            this.Flow6_Document_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow6_Document_CB.Name = "Flow6_Document_CB";
-            this.Flow6_Document_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_Document_CB.TabIndex = 32;
-            // 
-            // label43
-            // 
-            this.label43.AutoSize = true;
-            this.label43.Location = new System.Drawing.Point(20, 75);
-            this.label43.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label43.Name = "label43";
-            this.label43.Size = new System.Drawing.Size(111, 16);
-            this.label43.TabIndex = 23;
-            this.label43.Text = "Производитель";
-            // 
-            // Flow6_WeightImpulse_TB
-            // 
-            this.Flow6_WeightImpulse_TB.Location = new System.Drawing.Point(192, 193);
-            this.Flow6_WeightImpulse_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow6_WeightImpulse_TB.Name = "Flow6_WeightImpulse_TB";
-            this.Flow6_WeightImpulse_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow6_WeightImpulse_TB.TabIndex = 31;
-            // 
-            // Flow6_Name_SI_CB
-            // 
-            this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
-            this.Flow6_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.Flow6_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.Flow6_Name_SI_CB.FormattingEnabled = true;
-            this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
-            this.Flow6_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
-            this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_Name_SI_CB.TabIndex = 20;
-            this.Flow6_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
-            this.Flow6_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
-            this.Flow6_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
-            // 
-            // label44
-            // 
-            this.label44.AutoSize = true;
-            this.label44.Location = new System.Drawing.Point(20, 199);
-            this.label44.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label44.Name = "label44";
-            this.label44.Size = new System.Drawing.Size(97, 16);
-            this.label44.TabIndex = 30;
-            this.label44.Text = "Вес импульса";
-            // 
-            // label45
-            // 
-            this.label45.AutoSize = true;
-            this.label45.Location = new System.Drawing.Point(20, 43);
-            this.label45.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label45.Name = "label45";
-            this.label45.Size = new System.Drawing.Size(32, 16);
-            this.label45.TabIndex = 21;
-            this.label45.Text = "Тип";
-            // 
-            // label46
-            // 
-            this.label46.AutoSize = true;
-            this.label46.Location = new System.Drawing.Point(20, 169);
-            this.label46.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label46.Name = "label46";
-            this.label46.Size = new System.Drawing.Size(157, 16);
-            this.label46.TabIndex = 29;
-            this.label46.Text = "Номинальный диаметр";
-            // 
-            // Flow6_Modification_CB
-            // 
-            this.Flow6_Modification_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.Flow6_Modification_CB.FormattingEnabled = true;
-            this.Flow6_Modification_CB.Location = new System.Drawing.Point(192, 102);
-            this.Flow6_Modification_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Flow6_Modification_CB.Name = "Flow6_Modification_CB";
-            this.Flow6_Modification_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_Modification_CB.TabIndex = 24;
-            // 
-            // label47
-            // 
-            this.label47.AutoSize = true;
-            this.label47.Location = new System.Drawing.Point(20, 107);
-            this.label47.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label47.Name = "label47";
-            this.label47.Size = new System.Drawing.Size(99, 16);
-            this.label47.TabIndex = 25;
-            this.label47.Text = "Модификация";
-            // 
-            // Flow6_ZavodskNomer_TB
-            // 
-            this.Flow6_ZavodskNomer_TB.Location = new System.Drawing.Point(192, 133);
-            this.Flow6_ZavodskNomer_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Flow6_ZavodskNomer_TB.Name = "Flow6_ZavodskNomer_TB";
-            this.Flow6_ZavodskNomer_TB.Size = new System.Drawing.Size(177, 22);
-            this.Flow6_ZavodskNomer_TB.TabIndex = 27;
-            // 
-            // label48
-            // 
-            this.label48.AutoSize = true;
-            this.label48.Location = new System.Drawing.Point(20, 139);
-            this.label48.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label48.Name = "label48";
-            this.label48.Size = new System.Drawing.Size(122, 16);
-            this.label48.TabIndex = 26;
-            this.label48.Text = "Заводской номер";
-            // 
-            // Next_B
-            // 
-            this.Next_B.Location = new System.Drawing.Point(1156, 727);
-            this.Next_B.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Next_B.Name = "Next_B";
-            this.Next_B.Size = new System.Drawing.Size(100, 28);
-            this.Next_B.TabIndex = 42;
-            this.Next_B.Text = "Далее";
-            this.Next_B.UseVisualStyleBackColor = true;
-            this.Next_B.Click += new System.EventHandler(this.Next_B_Click);
-            // 
-            // button1
-            // 
-            this.button1.Location = new System.Drawing.Point(68, 727);
-            this.button1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(100, 28);
-            this.button1.TabIndex = 43;
-            this.button1.Text = "Выход";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            label10.AutoSize = true;
+            label10.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label10.Location = new Point(18, 0);
+            label10.Margin = new Padding(4, 0, 4, 0);
+            label10.Name = "label10";
+            label10.Size = new Size(156, 24);
+            label10.TabIndex = 35;
+            label10.Text = "Расходомер №2";
             // 
             // Rashodomer2_CB
             // 
-            this.Rashodomer2_CB.AutoSize = true;
-            this.Rashodomer2_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer2_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer2_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer2_CB.Name = "Rashodomer2_CB";
-            this.Rashodomer2_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer2_CB.TabIndex = 45;
-            this.Rashodomer2_CB.Text = "Установлен";
-            this.Rashodomer2_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer2_CB.CheckedChanged += new System.EventHandler(this.Rashodomer2_CB_CheckedChanged);
+            Rashodomer2_CB.AutoSize = true;
+            Rashodomer2_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer2_CB.Location = new Point(228, 0);
+            Rashodomer2_CB.Margin = new Padding(4);
+            Rashodomer2_CB.Name = "Rashodomer2_CB";
+            Rashodomer2_CB.Size = new Size(97, 17);
+            Rashodomer2_CB.TabIndex = 45;
+            Rashodomer2_CB.Text = "Установлен";
+            Rashodomer2_CB.UseVisualStyleBackColor = true;
+            Rashodomer2_CB.CheckedChanged += Rashodomer2_CB_CheckedChanged;
+            // 
+            // Flow2_Diameter_CB
+            // 
+            Flow2_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow2_Diameter_CB.FormattingEnabled = true;
+            Flow2_Diameter_CB.Location = new Point(168, 152);
+            Flow2_Diameter_CB.Margin = new Padding(4);
+            Flow2_Diameter_CB.Name = "Flow2_Diameter_CB";
+            Flow2_Diameter_CB.Size = new Size(155, 23);
+            Flow2_Diameter_CB.TabIndex = 28;
+            // 
+            // label11
+            // 
+            label11.AutoSize = true;
+            label11.Location = new Point(18, 215);
+            label11.Margin = new Padding(4, 0, 4, 0);
+            label11.Name = "label11";
+            label11.Size = new Size(125, 15);
+            label11.TabIndex = 33;
+            label11.Text = "Документ на поверку";
+            // 
+            // Flow2_GosReestr_CB
+            // 
+            Flow2_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow2_GosReestr_CB.FormattingEnabled = true;
+            Flow2_GosReestr_CB.Location = new Point(168, 67);
+            Flow2_GosReestr_CB.Margin = new Padding(4);
+            Flow2_GosReestr_CB.Name = "Flow2_GosReestr_CB";
+            Flow2_GosReestr_CB.Size = new Size(155, 23);
+            Flow2_GosReestr_CB.TabIndex = 22;
+            Flow2_GosReestr_CB.SelectedIndexChanged += Flow2_GosReestr_CB_SelectedIndexChanged;
+            // 
+            // Flow2_Document_CB
+            // 
+            Flow2_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow2_Document_CB.FormattingEnabled = true;
+            Flow2_Document_CB.Location = new Point(168, 209);
+            Flow2_Document_CB.Margin = new Padding(4);
+            Flow2_Document_CB.Name = "Flow2_Document_CB";
+            Flow2_Document_CB.Size = new Size(155, 23);
+            Flow2_Document_CB.TabIndex = 32;
+            // 
+            // label12
+            // 
+            label12.AutoSize = true;
+            label12.Location = new Point(18, 70);
+            label12.Margin = new Padding(4, 0, 4, 0);
+            label12.Name = "label12";
+            label12.Size = new Size(92, 15);
+            label12.TabIndex = 23;
+            label12.Text = "Производитель";
+            // 
+            // Flow2_WeightImpulse_TB
+            // 
+            Flow2_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow2_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow2_WeightImpulse_TB.Name = "Flow2_WeightImpulse_TB";
+            Flow2_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow2_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow2_Name_SI_CB
+            // 
+            Flow2_Name_SI_CB.AutoCompleteMode = AutoCompleteMode.Suggest;
+            Flow2_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2_Name_SI_CB.FormattingEnabled = true;
+            Flow2_Name_SI_CB.Location = new Point(168, 38);
+            Flow2_Name_SI_CB.Margin = new Padding(4);
+            Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
+            Flow2_Name_SI_CB.Size = new Size(155, 23);
+            Flow2_Name_SI_CB.TabIndex = 20;
+            Flow2_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow2_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow2_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            // 
+            // label13
+            // 
+            label13.AutoSize = true;
+            label13.Location = new Point(18, 187);
+            label13.Margin = new Padding(4, 0, 4, 0);
+            label13.Name = "label13";
+            label13.Size = new Size(83, 15);
+            label13.TabIndex = 30;
+            label13.Text = "Вес импульса";
+            // 
+            // label14
+            // 
+            label14.AutoSize = true;
+            label14.Location = new Point(18, 40);
+            label14.Margin = new Padding(4, 0, 4, 0);
+            label14.Name = "label14";
+            label14.Size = new Size(28, 15);
+            label14.TabIndex = 21;
+            label14.Text = "Тип";
+            label14.Click += label14_Click;
+            // 
+            // label15
+            // 
+            label15.AutoSize = true;
+            label15.Location = new Point(18, 158);
+            label15.Margin = new Padding(4, 0, 4, 0);
+            label15.Name = "label15";
+            label15.Size = new Size(137, 15);
+            label15.TabIndex = 29;
+            label15.Text = "Номинальный диаметр";
+            // 
+            // Flow2_Modification_CB
+            // 
+            Flow2_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow2_Modification_CB.FormattingEnabled = true;
+            Flow2_Modification_CB.Location = new Point(168, 96);
+            Flow2_Modification_CB.Margin = new Padding(4);
+            Flow2_Modification_CB.Name = "Flow2_Modification_CB";
+            Flow2_Modification_CB.Size = new Size(155, 23);
+            Flow2_Modification_CB.TabIndex = 24;
+            // 
+            // label16
+            // 
+            label16.AutoSize = true;
+            label16.Location = new Point(18, 100);
+            label16.Margin = new Padding(4, 0, 4, 0);
+            label16.Name = "label16";
+            label16.Size = new Size(86, 15);
+            label16.TabIndex = 25;
+            label16.Text = "Модификация";
+            // 
+            // Flow2_ZavodskNomer_TB
+            // 
+            Flow2_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow2_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow2_ZavodskNomer_TB.Name = "Flow2_ZavodskNomer_TB";
+            Flow2_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow2_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label17
+            // 
+            label17.AutoSize = true;
+            label17.Location = new Point(18, 130);
+            label17.Margin = new Padding(4, 0, 4, 0);
+            label17.Name = "label17";
+            label17.Size = new Size(104, 15);
+            label17.TabIndex = 26;
+            label17.Text = "Заводской номер";
+            // 
+            // Rashodomer3_GB
+            // 
+            Rashodomer3_GB.Controls.Add(label9);
+            Rashodomer3_GB.Controls.Add(Rashodomer3_CB);
+            Rashodomer3_GB.Controls.Add(Flow3_Diameter_CB);
+            Rashodomer3_GB.Controls.Add(label18);
+            Rashodomer3_GB.Controls.Add(Flow3_GosReestr_CB);
+            Rashodomer3_GB.Controls.Add(Flow3_Document_CB);
+            Rashodomer3_GB.Controls.Add(label19);
+            Rashodomer3_GB.Controls.Add(Flow3_WeightImpulse_TB);
+            Rashodomer3_GB.Controls.Add(Flow3_Name_SI_CB);
+            Rashodomer3_GB.Controls.Add(label20);
+            Rashodomer3_GB.Controls.Add(label21);
+            Rashodomer3_GB.Controls.Add(label22);
+            Rashodomer3_GB.Controls.Add(Flow3_Modification_CB);
+            Rashodomer3_GB.Controls.Add(label23);
+            Rashodomer3_GB.Controls.Add(Flow3_ZavodskNomer_TB);
+            Rashodomer3_GB.Controls.Add(label24);
+            Rashodomer3_GB.Location = new Point(409, 56);
+            Rashodomer3_GB.Margin = new Padding(4);
+            Rashodomer3_GB.Name = "Rashodomer3_GB";
+            Rashodomer3_GB.Padding = new Padding(4);
+            Rashodomer3_GB.Size = new Size(342, 281);
+            Rashodomer3_GB.TabIndex = 37;
+            Rashodomer3_GB.TabStop = false;
+            Rashodomer3_GB.Tag = "FirstFlowmeter";
+            // 
+            // label9
+            // 
+            label9.AutoSize = true;
+            label9.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label9.Location = new Point(18, 0);
+            label9.Margin = new Padding(4, 0, 4, 0);
+            label9.Name = "label9";
+            label9.Size = new Size(156, 24);
+            label9.TabIndex = 35;
+            label9.Text = "Расходомер №3";
             // 
             // Rashodomer3_CB
             // 
-            this.Rashodomer3_CB.AutoSize = true;
-            this.Rashodomer3_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer3_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer3_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer3_CB.Name = "Rashodomer3_CB";
-            this.Rashodomer3_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer3_CB.TabIndex = 46;
-            this.Rashodomer3_CB.Text = "Установлен";
-            this.Rashodomer3_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer3_CB.CheckedChanged += new System.EventHandler(this.Rashodomer3_CB_CheckedChanged);
+            Rashodomer3_CB.AutoSize = true;
+            Rashodomer3_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer3_CB.Location = new Point(228, 0);
+            Rashodomer3_CB.Margin = new Padding(4);
+            Rashodomer3_CB.Name = "Rashodomer3_CB";
+            Rashodomer3_CB.Size = new Size(97, 17);
+            Rashodomer3_CB.TabIndex = 46;
+            Rashodomer3_CB.Text = "Установлен";
+            Rashodomer3_CB.UseVisualStyleBackColor = true;
+            Rashodomer3_CB.CheckedChanged += Rashodomer3_CB_CheckedChanged;
             // 
-            // Rashodomer6_CB
+            // Flow3_Diameter_CB
             // 
-            this.Rashodomer6_CB.AutoSize = true;
-            this.Rashodomer6_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer6_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer6_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer6_CB.Name = "Rashodomer6_CB";
-            this.Rashodomer6_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer6_CB.TabIndex = 49;
-            this.Rashodomer6_CB.Text = "Установлен";
-            this.Rashodomer6_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer6_CB.CheckedChanged += new System.EventHandler(this.Rashodomer6_CB_CheckedChanged);
+            Flow3_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow3_Diameter_CB.FormattingEnabled = true;
+            Flow3_Diameter_CB.Location = new Point(168, 152);
+            Flow3_Diameter_CB.Margin = new Padding(4);
+            Flow3_Diameter_CB.Name = "Flow3_Diameter_CB";
+            Flow3_Diameter_CB.Size = new Size(155, 23);
+            Flow3_Diameter_CB.TabIndex = 28;
             // 
-            // Rashodomer5_CB
+            // label18
             // 
-            this.Rashodomer5_CB.AutoSize = true;
-            this.Rashodomer5_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer5_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer5_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer5_CB.Name = "Rashodomer5_CB";
-            this.Rashodomer5_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer5_CB.TabIndex = 48;
-            this.Rashodomer5_CB.Text = "Установлен";
-            this.Rashodomer5_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer5_CB.CheckedChanged += new System.EventHandler(this.Rashodomer5_CB_CheckedChanged);
+            label18.AutoSize = true;
+            label18.Location = new Point(18, 215);
+            label18.Margin = new Padding(4, 0, 4, 0);
+            label18.Name = "label18";
+            label18.Size = new Size(125, 15);
+            label18.TabIndex = 33;
+            label18.Text = "Документ на поверку";
+            // 
+            // Flow3_GosReestr_CB
+            // 
+            Flow3_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow3_GosReestr_CB.FormattingEnabled = true;
+            Flow3_GosReestr_CB.Location = new Point(168, 67);
+            Flow3_GosReestr_CB.Margin = new Padding(4);
+            Flow3_GosReestr_CB.Name = "Flow3_GosReestr_CB";
+            Flow3_GosReestr_CB.Size = new Size(155, 23);
+            Flow3_GosReestr_CB.TabIndex = 22;
+            Flow3_GosReestr_CB.SelectedIndexChanged += Flow3_GosReestr_CB_SelectedIndexChanged;
+            // 
+            // Flow3_Document_CB
+            // 
+            Flow3_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow3_Document_CB.FormattingEnabled = true;
+            Flow3_Document_CB.Location = new Point(168, 209);
+            Flow3_Document_CB.Margin = new Padding(4);
+            Flow3_Document_CB.Name = "Flow3_Document_CB";
+            Flow3_Document_CB.Size = new Size(155, 23);
+            Flow3_Document_CB.TabIndex = 32;
+            // 
+            // label19
+            // 
+            label19.AutoSize = true;
+            label19.Location = new Point(18, 70);
+            label19.Margin = new Padding(4, 0, 4, 0);
+            label19.Name = "label19";
+            label19.Size = new Size(92, 15);
+            label19.TabIndex = 23;
+            label19.Text = "Производитель";
+            // 
+            // Flow3_WeightImpulse_TB
+            // 
+            Flow3_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow3_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow3_WeightImpulse_TB.Name = "Flow3_WeightImpulse_TB";
+            Flow3_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow3_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow3_Name_SI_CB
+            // 
+            Flow3_Name_SI_CB.AutoCompleteMode = AutoCompleteMode.Suggest;
+            Flow3_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3_Name_SI_CB.FormattingEnabled = true;
+            Flow3_Name_SI_CB.Location = new Point(168, 38);
+            Flow3_Name_SI_CB.Margin = new Padding(4);
+            Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
+            Flow3_Name_SI_CB.Size = new Size(155, 23);
+            Flow3_Name_SI_CB.TabIndex = 20;
+            Flow3_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow3_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow3_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            // 
+            // label20
+            // 
+            label20.AutoSize = true;
+            label20.Location = new Point(18, 187);
+            label20.Margin = new Padding(4, 0, 4, 0);
+            label20.Name = "label20";
+            label20.Size = new Size(83, 15);
+            label20.TabIndex = 30;
+            label20.Text = "Вес импульса";
+            // 
+            // label21
+            // 
+            label21.AutoSize = true;
+            label21.Location = new Point(18, 40);
+            label21.Margin = new Padding(4, 0, 4, 0);
+            label21.Name = "label21";
+            label21.Size = new Size(28, 15);
+            label21.TabIndex = 21;
+            label21.Text = "Тип";
+            // 
+            // label22
+            // 
+            label22.AutoSize = true;
+            label22.Location = new Point(18, 158);
+            label22.Margin = new Padding(4, 0, 4, 0);
+            label22.Name = "label22";
+            label22.Size = new Size(137, 15);
+            label22.TabIndex = 29;
+            label22.Text = "Номинальный диаметр";
+            // 
+            // Flow3_Modification_CB
+            // 
+            Flow3_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow3_Modification_CB.FormattingEnabled = true;
+            Flow3_Modification_CB.Location = new Point(168, 96);
+            Flow3_Modification_CB.Margin = new Padding(4);
+            Flow3_Modification_CB.Name = "Flow3_Modification_CB";
+            Flow3_Modification_CB.Size = new Size(155, 23);
+            Flow3_Modification_CB.TabIndex = 24;
+            // 
+            // label23
+            // 
+            label23.AutoSize = true;
+            label23.Location = new Point(18, 100);
+            label23.Margin = new Padding(4, 0, 4, 0);
+            label23.Name = "label23";
+            label23.Size = new Size(86, 15);
+            label23.TabIndex = 25;
+            label23.Text = "Модификация";
+            // 
+            // Flow3_ZavodskNomer_TB
+            // 
+            Flow3_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow3_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow3_ZavodskNomer_TB.Name = "Flow3_ZavodskNomer_TB";
+            Flow3_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow3_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label24
+            // 
+            label24.AutoSize = true;
+            label24.Location = new Point(18, 130);
+            label24.Margin = new Padding(4, 0, 4, 0);
+            label24.Name = "label24";
+            label24.Size = new Size(104, 15);
+            label24.TabIndex = 26;
+            label24.Text = "Заводской номер";
+            // 
+            // Rashodomer4_GB
+            // 
+            Rashodomer4_GB.Controls.Add(label25);
+            Rashodomer4_GB.Controls.Add(Rashodomer4_CB);
+            Rashodomer4_GB.Controls.Add(Flow4_Diameter_CB);
+            Rashodomer4_GB.Controls.Add(label26);
+            Rashodomer4_GB.Controls.Add(Flow4_GosReestr_CB);
+            Rashodomer4_GB.Controls.Add(Flow4_Document_CB);
+            Rashodomer4_GB.Controls.Add(label27);
+            Rashodomer4_GB.Controls.Add(Flow4_WeightImpulse_TB);
+            Rashodomer4_GB.Controls.Add(Flow4_Name_SI_CB);
+            Rashodomer4_GB.Controls.Add(label28);
+            Rashodomer4_GB.Controls.Add(label29);
+            Rashodomer4_GB.Controls.Add(label30);
+            Rashodomer4_GB.Controls.Add(Flow4_Modification_CB);
+            Rashodomer4_GB.Controls.Add(label31);
+            Rashodomer4_GB.Controls.Add(Flow4_ZavodskNomer_TB);
+            Rashodomer4_GB.Controls.Add(label32);
+            Rashodomer4_GB.Location = new Point(409, 346);
+            Rashodomer4_GB.Margin = new Padding(4);
+            Rashodomer4_GB.Name = "Rashodomer4_GB";
+            Rashodomer4_GB.Padding = new Padding(4);
+            Rashodomer4_GB.Size = new Size(342, 281);
+            Rashodomer4_GB.TabIndex = 38;
+            Rashodomer4_GB.TabStop = false;
+            Rashodomer4_GB.Tag = "FirstFlowmeter";
+            // 
+            // label25
+            // 
+            label25.AutoSize = true;
+            label25.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label25.Location = new Point(18, 0);
+            label25.Margin = new Padding(4, 0, 4, 0);
+            label25.Name = "label25";
+            label25.Size = new Size(156, 24);
+            label25.TabIndex = 35;
+            label25.Text = "Расходомер №4";
             // 
             // Rashodomer4_CB
             // 
-            this.Rashodomer4_CB.AutoSize = true;
-            this.Rashodomer4_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer4_CB.Location = new System.Drawing.Point(260, 0);
-            this.Rashodomer4_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer4_CB.Name = "Rashodomer4_CB";
-            this.Rashodomer4_CB.Size = new System.Drawing.Size(102, 21);
-            this.Rashodomer4_CB.TabIndex = 47;
-            this.Rashodomer4_CB.Text = "Установлен";
-            this.Rashodomer4_CB.UseVisualStyleBackColor = true;
-            this.Rashodomer4_CB.CheckedChanged += new System.EventHandler(this.Rashodomer4_CB_CheckedChanged);
+            Rashodomer4_CB.AutoSize = true;
+            Rashodomer4_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer4_CB.Location = new Point(228, 0);
+            Rashodomer4_CB.Margin = new Padding(4);
+            Rashodomer4_CB.Name = "Rashodomer4_CB";
+            Rashodomer4_CB.Size = new Size(97, 17);
+            Rashodomer4_CB.TabIndex = 47;
+            Rashodomer4_CB.Text = "Установлен";
+            Rashodomer4_CB.UseVisualStyleBackColor = true;
+            Rashodomer4_CB.CheckedChanged += Rashodomer4_CB_CheckedChanged;
+            // 
+            // Flow4_Diameter_CB
+            // 
+            Flow4_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow4_Diameter_CB.FormattingEnabled = true;
+            Flow4_Diameter_CB.Location = new Point(168, 152);
+            Flow4_Diameter_CB.Margin = new Padding(4);
+            Flow4_Diameter_CB.Name = "Flow4_Diameter_CB";
+            Flow4_Diameter_CB.Size = new Size(155, 23);
+            Flow4_Diameter_CB.TabIndex = 28;
+            // 
+            // label26
+            // 
+            label26.AutoSize = true;
+            label26.Location = new Point(18, 215);
+            label26.Margin = new Padding(4, 0, 4, 0);
+            label26.Name = "label26";
+            label26.Size = new Size(125, 15);
+            label26.TabIndex = 33;
+            label26.Text = "Документ на поверку";
+            // 
+            // Flow4_GosReestr_CB
+            // 
+            Flow4_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow4_GosReestr_CB.FormattingEnabled = true;
+            Flow4_GosReestr_CB.Location = new Point(168, 67);
+            Flow4_GosReestr_CB.Margin = new Padding(4);
+            Flow4_GosReestr_CB.Name = "Flow4_GosReestr_CB";
+            Flow4_GosReestr_CB.Size = new Size(155, 23);
+            Flow4_GosReestr_CB.TabIndex = 22;
+            Flow4_GosReestr_CB.SelectedIndexChanged += Flow4_GosReestr_CB_SelectedIndexChanged;
+            // 
+            // Flow4_Document_CB
+            // 
+            Flow4_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow4_Document_CB.FormattingEnabled = true;
+            Flow4_Document_CB.Location = new Point(168, 209);
+            Flow4_Document_CB.Margin = new Padding(4);
+            Flow4_Document_CB.Name = "Flow4_Document_CB";
+            Flow4_Document_CB.Size = new Size(155, 23);
+            Flow4_Document_CB.TabIndex = 32;
+            // 
+            // label27
+            // 
+            label27.AutoSize = true;
+            label27.Location = new Point(18, 70);
+            label27.Margin = new Padding(4, 0, 4, 0);
+            label27.Name = "label27";
+            label27.Size = new Size(92, 15);
+            label27.TabIndex = 23;
+            label27.Text = "Производитель";
+            // 
+            // Flow4_WeightImpulse_TB
+            // 
+            Flow4_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow4_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow4_WeightImpulse_TB.Name = "Flow4_WeightImpulse_TB";
+            Flow4_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow4_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow4_Name_SI_CB
+            // 
+            Flow4_Name_SI_CB.AutoCompleteMode = AutoCompleteMode.Suggest;
+            Flow4_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4_Name_SI_CB.FormattingEnabled = true;
+            Flow4_Name_SI_CB.Location = new Point(168, 38);
+            Flow4_Name_SI_CB.Margin = new Padding(4);
+            Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
+            Flow4_Name_SI_CB.Size = new Size(155, 23);
+            Flow4_Name_SI_CB.TabIndex = 20;
+            Flow4_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow4_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow4_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            // 
+            // label28
+            // 
+            label28.AutoSize = true;
+            label28.Location = new Point(18, 187);
+            label28.Margin = new Padding(4, 0, 4, 0);
+            label28.Name = "label28";
+            label28.Size = new Size(83, 15);
+            label28.TabIndex = 30;
+            label28.Text = "Вес импульса";
+            // 
+            // label29
+            // 
+            label29.AutoSize = true;
+            label29.Location = new Point(18, 40);
+            label29.Margin = new Padding(4, 0, 4, 0);
+            label29.Name = "label29";
+            label29.Size = new Size(117, 15);
+            label29.TabIndex = 21;
+            label29.Text = "Наиименование СИ";
+            // 
+            // label30
+            // 
+            label30.AutoSize = true;
+            label30.Location = new Point(18, 158);
+            label30.Margin = new Padding(4, 0, 4, 0);
+            label30.Name = "label30";
+            label30.Size = new Size(137, 15);
+            label30.TabIndex = 29;
+            label30.Text = "Номинальный диаметр";
+            // 
+            // Flow4_Modification_CB
+            // 
+            Flow4_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow4_Modification_CB.FormattingEnabled = true;
+            Flow4_Modification_CB.Location = new Point(168, 96);
+            Flow4_Modification_CB.Margin = new Padding(4);
+            Flow4_Modification_CB.Name = "Flow4_Modification_CB";
+            Flow4_Modification_CB.Size = new Size(155, 23);
+            Flow4_Modification_CB.TabIndex = 24;
+            // 
+            // label31
+            // 
+            label31.AutoSize = true;
+            label31.Location = new Point(18, 100);
+            label31.Margin = new Padding(4, 0, 4, 0);
+            label31.Name = "label31";
+            label31.Size = new Size(86, 15);
+            label31.TabIndex = 25;
+            label31.Text = "Модификация";
+            // 
+            // Flow4_ZavodskNomer_TB
+            // 
+            Flow4_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow4_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow4_ZavodskNomer_TB.Name = "Flow4_ZavodskNomer_TB";
+            Flow4_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow4_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label32
+            // 
+            label32.AutoSize = true;
+            label32.Location = new Point(18, 130);
+            label32.Margin = new Padding(4, 0, 4, 0);
+            label32.Name = "label32";
+            label32.Size = new Size(104, 15);
+            label32.TabIndex = 26;
+            label32.Text = "Заводской номер";
+            // 
+            // Rashodomer5_GB
+            // 
+            Rashodomer5_GB.Controls.Add(label33);
+            Rashodomer5_GB.Controls.Add(Rashodomer5_CB);
+            Rashodomer5_GB.Controls.Add(Flow5_Diameter_CB);
+            Rashodomer5_GB.Controls.Add(label34);
+            Rashodomer5_GB.Controls.Add(Flow5_GosReestr_CB);
+            Rashodomer5_GB.Controls.Add(Flow5_Document_CB);
+            Rashodomer5_GB.Controls.Add(label35);
+            Rashodomer5_GB.Controls.Add(Flow5_WeightImpulse_TB);
+            Rashodomer5_GB.Controls.Add(Flow5_Name_SI_CB);
+            Rashodomer5_GB.Controls.Add(label36);
+            Rashodomer5_GB.Controls.Add(label37);
+            Rashodomer5_GB.Controls.Add(label38);
+            Rashodomer5_GB.Controls.Add(Flow5_Modification_CB);
+            Rashodomer5_GB.Controls.Add(label39);
+            Rashodomer5_GB.Controls.Add(Flow5_ZavodskNomer_TB);
+            Rashodomer5_GB.Controls.Add(label40);
+            Rashodomer5_GB.Location = new Point(757, 56);
+            Rashodomer5_GB.Margin = new Padding(4);
+            Rashodomer5_GB.Name = "Rashodomer5_GB";
+            Rashodomer5_GB.Padding = new Padding(4);
+            Rashodomer5_GB.Size = new Size(342, 281);
+            Rashodomer5_GB.TabIndex = 37;
+            Rashodomer5_GB.TabStop = false;
+            Rashodomer5_GB.Tag = "FirstFlowmeter";
+            // 
+            // label33
+            // 
+            label33.AutoSize = true;
+            label33.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label33.Location = new Point(18, 0);
+            label33.Margin = new Padding(4, 0, 4, 0);
+            label33.Name = "label33";
+            label33.Size = new Size(156, 24);
+            label33.TabIndex = 35;
+            label33.Text = "Расходомер №5";
+            // 
+            // Rashodomer5_CB
+            // 
+            Rashodomer5_CB.AutoSize = true;
+            Rashodomer5_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer5_CB.Location = new Point(228, 0);
+            Rashodomer5_CB.Margin = new Padding(4);
+            Rashodomer5_CB.Name = "Rashodomer5_CB";
+            Rashodomer5_CB.Size = new Size(97, 17);
+            Rashodomer5_CB.TabIndex = 48;
+            Rashodomer5_CB.Text = "Установлен";
+            Rashodomer5_CB.UseVisualStyleBackColor = true;
+            Rashodomer5_CB.CheckedChanged += Rashodomer5_CB_CheckedChanged;
+            // 
+            // Flow5_Diameter_CB
+            // 
+            Flow5_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow5_Diameter_CB.FormattingEnabled = true;
+            Flow5_Diameter_CB.Location = new Point(168, 152);
+            Flow5_Diameter_CB.Margin = new Padding(4);
+            Flow5_Diameter_CB.Name = "Flow5_Diameter_CB";
+            Flow5_Diameter_CB.Size = new Size(155, 23);
+            Flow5_Diameter_CB.TabIndex = 28;
+            // 
+            // label34
+            // 
+            label34.AutoSize = true;
+            label34.Location = new Point(18, 215);
+            label34.Margin = new Padding(4, 0, 4, 0);
+            label34.Name = "label34";
+            label34.Size = new Size(125, 15);
+            label34.TabIndex = 33;
+            label34.Text = "Документ на поверку";
+            // 
+            // Flow5_GosReestr_CB
+            // 
+            Flow5_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow5_GosReestr_CB.FormattingEnabled = true;
+            Flow5_GosReestr_CB.Location = new Point(168, 67);
+            Flow5_GosReestr_CB.Margin = new Padding(4);
+            Flow5_GosReestr_CB.Name = "Flow5_GosReestr_CB";
+            Flow5_GosReestr_CB.Size = new Size(155, 23);
+            Flow5_GosReestr_CB.TabIndex = 22;
+            Flow5_GosReestr_CB.SelectedIndexChanged += Flow5_GosReestr_CB_SelectedIndexChanged;
+            // 
+            // Flow5_Document_CB
+            // 
+            Flow5_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow5_Document_CB.FormattingEnabled = true;
+            Flow5_Document_CB.Location = new Point(168, 209);
+            Flow5_Document_CB.Margin = new Padding(4);
+            Flow5_Document_CB.Name = "Flow5_Document_CB";
+            Flow5_Document_CB.Size = new Size(155, 23);
+            Flow5_Document_CB.TabIndex = 32;
+            // 
+            // label35
+            // 
+            label35.AutoSize = true;
+            label35.Location = new Point(18, 70);
+            label35.Margin = new Padding(4, 0, 4, 0);
+            label35.Name = "label35";
+            label35.Size = new Size(92, 15);
+            label35.TabIndex = 23;
+            label35.Text = "Производитель";
+            // 
+            // Flow5_WeightImpulse_TB
+            // 
+            Flow5_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow5_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow5_WeightImpulse_TB.Name = "Flow5_WeightImpulse_TB";
+            Flow5_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow5_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow5_Name_SI_CB
+            // 
+            Flow5_Name_SI_CB.AutoCompleteMode = AutoCompleteMode.Suggest;
+            Flow5_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5_Name_SI_CB.FormattingEnabled = true;
+            Flow5_Name_SI_CB.Location = new Point(168, 38);
+            Flow5_Name_SI_CB.Margin = new Padding(4);
+            Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
+            Flow5_Name_SI_CB.Size = new Size(155, 23);
+            Flow5_Name_SI_CB.TabIndex = 20;
+            Flow5_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow5_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow5_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            // 
+            // label36
+            // 
+            label36.AutoSize = true;
+            label36.Location = new Point(18, 187);
+            label36.Margin = new Padding(4, 0, 4, 0);
+            label36.Name = "label36";
+            label36.Size = new Size(83, 15);
+            label36.TabIndex = 30;
+            label36.Text = "Вес импульса";
+            // 
+            // label37
+            // 
+            label37.AutoSize = true;
+            label37.Location = new Point(18, 40);
+            label37.Margin = new Padding(4, 0, 4, 0);
+            label37.Name = "label37";
+            label37.Size = new Size(28, 15);
+            label37.TabIndex = 21;
+            label37.Text = "Тип";
+            // 
+            // label38
+            // 
+            label38.AutoSize = true;
+            label38.Location = new Point(18, 158);
+            label38.Margin = new Padding(4, 0, 4, 0);
+            label38.Name = "label38";
+            label38.Size = new Size(137, 15);
+            label38.TabIndex = 29;
+            label38.Text = "Номинальный диаметр";
+            // 
+            // Flow5_Modification_CB
+            // 
+            Flow5_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow5_Modification_CB.FormattingEnabled = true;
+            Flow5_Modification_CB.Location = new Point(168, 96);
+            Flow5_Modification_CB.Margin = new Padding(4);
+            Flow5_Modification_CB.Name = "Flow5_Modification_CB";
+            Flow5_Modification_CB.Size = new Size(155, 23);
+            Flow5_Modification_CB.TabIndex = 24;
+            // 
+            // label39
+            // 
+            label39.AutoSize = true;
+            label39.Location = new Point(18, 100);
+            label39.Margin = new Padding(4, 0, 4, 0);
+            label39.Name = "label39";
+            label39.Size = new Size(86, 15);
+            label39.TabIndex = 25;
+            label39.Text = "Модификация";
+            // 
+            // Flow5_ZavodskNomer_TB
+            // 
+            Flow5_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow5_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow5_ZavodskNomer_TB.Name = "Flow5_ZavodskNomer_TB";
+            Flow5_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow5_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label40
+            // 
+            label40.AutoSize = true;
+            label40.Location = new Point(18, 130);
+            label40.Margin = new Padding(4, 0, 4, 0);
+            label40.Name = "label40";
+            label40.Size = new Size(104, 15);
+            label40.TabIndex = 26;
+            label40.Text = "Заводской номер";
+            // 
+            // Rashodomer6_GB
+            // 
+            Rashodomer6_GB.Controls.Add(label41);
+            Rashodomer6_GB.Controls.Add(Rashodomer6_CB);
+            Rashodomer6_GB.Controls.Add(Flow6_Diameter_CB);
+            Rashodomer6_GB.Controls.Add(label42);
+            Rashodomer6_GB.Controls.Add(Flow6_GosReestr_CB);
+            Rashodomer6_GB.Controls.Add(Flow6_Document_CB);
+            Rashodomer6_GB.Controls.Add(label43);
+            Rashodomer6_GB.Controls.Add(Flow6_WeightImpulse_TB);
+            Rashodomer6_GB.Controls.Add(Flow6_Name_SI_CB);
+            Rashodomer6_GB.Controls.Add(label44);
+            Rashodomer6_GB.Controls.Add(label45);
+            Rashodomer6_GB.Controls.Add(label46);
+            Rashodomer6_GB.Controls.Add(Flow6_Modification_CB);
+            Rashodomer6_GB.Controls.Add(label47);
+            Rashodomer6_GB.Controls.Add(Flow6_ZavodskNomer_TB);
+            Rashodomer6_GB.Controls.Add(label48);
+            Rashodomer6_GB.Location = new Point(757, 346);
+            Rashodomer6_GB.Margin = new Padding(4);
+            Rashodomer6_GB.Name = "Rashodomer6_GB";
+            Rashodomer6_GB.Padding = new Padding(4);
+            Rashodomer6_GB.Size = new Size(342, 281);
+            Rashodomer6_GB.TabIndex = 37;
+            Rashodomer6_GB.TabStop = false;
+            Rashodomer6_GB.Tag = "FirstFlowmeter";
+            Rashodomer6_GB.Enter += groupBox6_Enter;
+            // 
+            // label41
+            // 
+            label41.AutoSize = true;
+            label41.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            label41.Location = new Point(18, 0);
+            label41.Margin = new Padding(4, 0, 4, 0);
+            label41.Name = "label41";
+            label41.Size = new Size(156, 24);
+            label41.TabIndex = 35;
+            label41.Text = "Расходомер №6";
+            // 
+            // Rashodomer6_CB
+            // 
+            Rashodomer6_CB.AutoSize = true;
+            Rashodomer6_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Rashodomer6_CB.Location = new Point(228, 0);
+            Rashodomer6_CB.Margin = new Padding(4);
+            Rashodomer6_CB.Name = "Rashodomer6_CB";
+            Rashodomer6_CB.Size = new Size(97, 17);
+            Rashodomer6_CB.TabIndex = 49;
+            Rashodomer6_CB.Text = "Установлен";
+            Rashodomer6_CB.UseVisualStyleBackColor = true;
+            Rashodomer6_CB.CheckedChanged += Rashodomer6_CB_CheckedChanged;
+            // 
+            // Flow6_Diameter_CB
+            // 
+            Flow6_Diameter_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow6_Diameter_CB.FormattingEnabled = true;
+            Flow6_Diameter_CB.Location = new Point(168, 152);
+            Flow6_Diameter_CB.Margin = new Padding(4);
+            Flow6_Diameter_CB.Name = "Flow6_Diameter_CB";
+            Flow6_Diameter_CB.Size = new Size(155, 23);
+            Flow6_Diameter_CB.TabIndex = 28;
+            // 
+            // label42
+            // 
+            label42.AutoSize = true;
+            label42.Location = new Point(18, 215);
+            label42.Margin = new Padding(4, 0, 4, 0);
+            label42.Name = "label42";
+            label42.Size = new Size(125, 15);
+            label42.TabIndex = 33;
+            label42.Text = "Документ на поверку";
+            // 
+            // Flow6_GosReestr_CB
+            // 
+            Flow6_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow6_GosReestr_CB.FormattingEnabled = true;
+            Flow6_GosReestr_CB.Location = new Point(168, 67);
+            Flow6_GosReestr_CB.Margin = new Padding(4);
+            Flow6_GosReestr_CB.Name = "Flow6_GosReestr_CB";
+            Flow6_GosReestr_CB.Size = new Size(155, 23);
+            Flow6_GosReestr_CB.TabIndex = 22;
+            Flow6_GosReestr_CB.SelectedIndexChanged += Flow6_GosReestr_CB_SelectedIndexChanged;
+            // 
+            // Flow6_Document_CB
+            // 
+            Flow6_Document_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow6_Document_CB.FormattingEnabled = true;
+            Flow6_Document_CB.Location = new Point(168, 209);
+            Flow6_Document_CB.Margin = new Padding(4);
+            Flow6_Document_CB.Name = "Flow6_Document_CB";
+            Flow6_Document_CB.Size = new Size(155, 23);
+            Flow6_Document_CB.TabIndex = 32;
+            // 
+            // label43
+            // 
+            label43.AutoSize = true;
+            label43.Location = new Point(18, 70);
+            label43.Margin = new Padding(4, 0, 4, 0);
+            label43.Name = "label43";
+            label43.Size = new Size(92, 15);
+            label43.TabIndex = 23;
+            label43.Text = "Производитель";
+            // 
+            // Flow6_WeightImpulse_TB
+            // 
+            Flow6_WeightImpulse_TB.Location = new Point(168, 181);
+            Flow6_WeightImpulse_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow6_WeightImpulse_TB.Name = "Flow6_WeightImpulse_TB";
+            Flow6_WeightImpulse_TB.Size = new Size(155, 23);
+            Flow6_WeightImpulse_TB.TabIndex = 31;
+            // 
+            // Flow6_Name_SI_CB
+            // 
+            Flow6_Name_SI_CB.AutoCompleteMode = AutoCompleteMode.Suggest;
+            Flow6_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6_Name_SI_CB.FormattingEnabled = true;
+            Flow6_Name_SI_CB.Location = new Point(168, 38);
+            Flow6_Name_SI_CB.Margin = new Padding(4);
+            Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
+            Flow6_Name_SI_CB.Size = new Size(155, 23);
+            Flow6_Name_SI_CB.TabIndex = 20;
+            Flow6_Name_SI_CB.Click += MeterTypeCB_Click;
+            Flow6_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow6_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            // 
+            // label44
+            // 
+            label44.AutoSize = true;
+            label44.Location = new Point(18, 187);
+            label44.Margin = new Padding(4, 0, 4, 0);
+            label44.Name = "label44";
+            label44.Size = new Size(83, 15);
+            label44.TabIndex = 30;
+            label44.Text = "Вес импульса";
+            // 
+            // label45
+            // 
+            label45.AutoSize = true;
+            label45.Location = new Point(18, 40);
+            label45.Margin = new Padding(4, 0, 4, 0);
+            label45.Name = "label45";
+            label45.Size = new Size(28, 15);
+            label45.TabIndex = 21;
+            label45.Text = "Тип";
+            // 
+            // label46
+            // 
+            label46.AutoSize = true;
+            label46.Location = new Point(18, 158);
+            label46.Margin = new Padding(4, 0, 4, 0);
+            label46.Name = "label46";
+            label46.Size = new Size(137, 15);
+            label46.TabIndex = 29;
+            label46.Text = "Номинальный диаметр";
+            // 
+            // Flow6_Modification_CB
+            // 
+            Flow6_Modification_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow6_Modification_CB.FormattingEnabled = true;
+            Flow6_Modification_CB.Location = new Point(168, 96);
+            Flow6_Modification_CB.Margin = new Padding(4);
+            Flow6_Modification_CB.Name = "Flow6_Modification_CB";
+            Flow6_Modification_CB.Size = new Size(155, 23);
+            Flow6_Modification_CB.TabIndex = 24;
+            // 
+            // label47
+            // 
+            label47.AutoSize = true;
+            label47.Location = new Point(18, 100);
+            label47.Margin = new Padding(4, 0, 4, 0);
+            label47.Name = "label47";
+            label47.Size = new Size(86, 15);
+            label47.TabIndex = 25;
+            label47.Text = "Модификация";
+            // 
+            // Flow6_ZavodskNomer_TB
+            // 
+            Flow6_ZavodskNomer_TB.Location = new Point(168, 125);
+            Flow6_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
+            Flow6_ZavodskNomer_TB.Name = "Flow6_ZavodskNomer_TB";
+            Flow6_ZavodskNomer_TB.Size = new Size(155, 23);
+            Flow6_ZavodskNomer_TB.TabIndex = 27;
+            // 
+            // label48
+            // 
+            label48.AutoSize = true;
+            label48.Location = new Point(18, 130);
+            label48.Margin = new Padding(4, 0, 4, 0);
+            label48.Name = "label48";
+            label48.Size = new Size(104, 15);
+            label48.TabIndex = 26;
+            label48.Text = "Заводской номер";
+            // 
+            // Next_B
+            // 
+            Next_B.Location = new Point(1012, 682);
+            Next_B.Margin = new Padding(4);
+            Next_B.Name = "Next_B";
+            Next_B.Size = new Size(88, 26);
+            Next_B.TabIndex = 42;
+            Next_B.Text = "Далее";
+            Next_B.UseVisualStyleBackColor = true;
+            Next_B.Click += Next_B_Click;
+            // 
+            // button1
+            // 
+            button1.Location = new Point(60, 682);
+            button1.Margin = new Padding(4);
+            button1.Name = "button1";
+            button1.Size = new Size(88, 26);
+            button1.TabIndex = 43;
+            button1.Text = "Выход";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
             // 
             // MetersSetupForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1323, 777);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.Next_B);
-            this.Controls.Add(this.Rashodomer6_GB);
-            this.Controls.Add(this.Rashodomer5_GB);
-            this.Controls.Add(this.Rashodomer4_GB);
-            this.Controls.Add(this.Rashodomer3_GB);
-            this.Controls.Add(this.Rashodomer2_GB);
-            this.Controls.Add(this.Rashodomer1_GB);
-            this.Controls.Add(this.label1);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Name = "MetersSetupForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Настройка параметров поверяемых преобразователей";
-            this.Load += new System.EventHandler(this.MetersSetupForm_Load);
-            this.Rashodomer1_GB.ResumeLayout(false);
-            this.Rashodomer1_GB.PerformLayout();
-            this.Rashodomer2_GB.ResumeLayout(false);
-            this.Rashodomer2_GB.PerformLayout();
-            this.Rashodomer3_GB.ResumeLayout(false);
-            this.Rashodomer3_GB.PerformLayout();
-            this.Rashodomer4_GB.ResumeLayout(false);
-            this.Rashodomer4_GB.PerformLayout();
-            this.Rashodomer5_GB.ResumeLayout(false);
-            this.Rashodomer5_GB.PerformLayout();
-            this.Rashodomer6_GB.ResumeLayout(false);
-            this.Rashodomer6_GB.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(1158, 728);
+            Controls.Add(button1);
+            Controls.Add(Next_B);
+            Controls.Add(Rashodomer6_GB);
+            Controls.Add(Rashodomer5_GB);
+            Controls.Add(Rashodomer4_GB);
+            Controls.Add(Rashodomer3_GB);
+            Controls.Add(Rashodomer2_GB);
+            Controls.Add(Rashodomer1_GB);
+            Controls.Add(label1);
+            Margin = new Padding(4);
+            Name = "MetersSetupForm";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Настройка параметров поверяемых преобразователей";
+            Load += MetersSetupForm_Load;
+            Rashodomer1_GB.ResumeLayout(false);
+            Rashodomer1_GB.PerformLayout();
+            Rashodomer2_GB.ResumeLayout(false);
+            Rashodomer2_GB.PerformLayout();
+            Rashodomer3_GB.ResumeLayout(false);
+            Rashodomer3_GB.PerformLayout();
+            Rashodomer4_GB.ResumeLayout(false);
+            Rashodomer4_GB.PerformLayout();
+            Rashodomer5_GB.ResumeLayout(false);
+            Rashodomer5_GB.PerformLayout();
+            Rashodomer6_GB.ResumeLayout(false);
+            Rashodomer6_GB.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -129,8 +129,6 @@ namespace PoverkaWinForms.Forms.Verifier
             this.label48 = new System.Windows.Forms.Label();
             this.Next_B = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
-            this.FlowmetersEnable_TB = new System.Windows.Forms.TextBox();
-            this.button2 = new System.Windows.Forms.Button();
             this.Rashodomer2_CB = new System.Windows.Forms.CheckBox();
             this.Rashodomer3_CB = new System.Windows.Forms.CheckBox();
             this.Rashodomer6_CB = new System.Windows.Forms.CheckBox();
@@ -298,6 +296,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer1_GB
             // 
             this.Rashodomer1_GB.Controls.Add(this.label8);
+            this.Rashodomer1_GB.Controls.Add(this.Rashodomer1_CB);
             this.Rashodomer1_GB.Controls.Add(this.Flow1_Diameter_CB);
             this.Rashodomer1_GB.Controls.Add(this.label7);
             this.Rashodomer1_GB.Controls.Add(this.Flow1_GosReestr_CB);
@@ -312,12 +311,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer1_GB.Controls.Add(this.label3);
             this.Rashodomer1_GB.Controls.Add(this.Flow1_ZavodskNomer_TB);
             this.Rashodomer1_GB.Controls.Add(this.label4);
-            this.Rashodomer1_GB.Enabled = false;
+            this.Rashodomer1_GB.Enabled = true;
             this.Rashodomer1_GB.Location = new System.Drawing.Point(68, 139);
             this.Rashodomer1_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer1_GB.Name = "Rashodomer1_GB";
             this.Rashodomer1_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer1_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer1_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer1_GB.TabIndex = 34;
             this.Rashodomer1_GB.TabStop = false;
             this.Rashodomer1_GB.Tag = "FirstFlowmeter";
@@ -326,7 +325,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label8.Location = new System.Drawing.Point(20, -6);
+            this.label8.Location = new System.Drawing.Point(20, 0);
             this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(195, 29);
@@ -337,7 +336,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Rashodomer1_CB.AutoSize = true;
             this.Rashodomer1_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer1_CB.Location = new System.Drawing.Point(352, 122);
+            this.Rashodomer1_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer1_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer1_CB.Name = "Rashodomer1_CB";
             this.Rashodomer1_CB.Size = new System.Drawing.Size(102, 21);
@@ -349,6 +348,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer2_GB
             // 
             this.Rashodomer2_GB.Controls.Add(this.label10);
+            this.Rashodomer2_GB.Controls.Add(this.Rashodomer2_CB);
             this.Rashodomer2_GB.Controls.Add(this.Flow2_Diameter_CB);
             this.Rashodomer2_GB.Controls.Add(this.label11);
             this.Rashodomer2_GB.Controls.Add(this.Flow2_GosReestr_CB);
@@ -363,12 +363,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer2_GB.Controls.Add(this.label16);
             this.Rashodomer2_GB.Controls.Add(this.Flow2_ZavodskNomer_TB);
             this.Rashodomer2_GB.Controls.Add(this.label17);
-            this.Rashodomer2_GB.Enabled = false;
+            this.Rashodomer2_GB.Enabled = true;
             this.Rashodomer2_GB.Location = new System.Drawing.Point(68, 448);
             this.Rashodomer2_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer2_GB.Name = "Rashodomer2_GB";
             this.Rashodomer2_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer2_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer2_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer2_GB.TabIndex = 36;
             this.Rashodomer2_GB.TabStop = false;
             this.Rashodomer2_GB.Tag = "FirstFlowmeter";
@@ -377,7 +377,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label10.AutoSize = true;
             this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label10.Location = new System.Drawing.Point(20, -6);
+            this.label10.Location = new System.Drawing.Point(20, 0);
             this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(195, 29);
@@ -525,6 +525,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer3_GB
             // 
             this.Rashodomer3_GB.Controls.Add(this.label9);
+            this.Rashodomer3_GB.Controls.Add(this.Rashodomer3_CB);
             this.Rashodomer3_GB.Controls.Add(this.Flow3_Diameter_CB);
             this.Rashodomer3_GB.Controls.Add(this.label18);
             this.Rashodomer3_GB.Controls.Add(this.Flow3_GosReestr_CB);
@@ -539,12 +540,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer3_GB.Controls.Add(this.label23);
             this.Rashodomer3_GB.Controls.Add(this.Flow3_ZavodskNomer_TB);
             this.Rashodomer3_GB.Controls.Add(this.label24);
-            this.Rashodomer3_GB.Enabled = false;
+            this.Rashodomer3_GB.Enabled = true;
             this.Rashodomer3_GB.Location = new System.Drawing.Point(467, 139);
             this.Rashodomer3_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer3_GB.Name = "Rashodomer3_GB";
             this.Rashodomer3_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer3_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer3_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer3_GB.TabIndex = 37;
             this.Rashodomer3_GB.TabStop = false;
             this.Rashodomer3_GB.Tag = "FirstFlowmeter";
@@ -553,7 +554,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label9.Location = new System.Drawing.Point(20, -6);
+            this.label9.Location = new System.Drawing.Point(20, 0);
             this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(195, 29);
@@ -700,6 +701,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer4_GB
             // 
             this.Rashodomer4_GB.Controls.Add(this.label25);
+            this.Rashodomer4_GB.Controls.Add(this.Rashodomer4_CB);
             this.Rashodomer4_GB.Controls.Add(this.Flow4_Diameter_CB);
             this.Rashodomer4_GB.Controls.Add(this.label26);
             this.Rashodomer4_GB.Controls.Add(this.Flow4_GosReestr_CB);
@@ -714,12 +716,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer4_GB.Controls.Add(this.label31);
             this.Rashodomer4_GB.Controls.Add(this.Flow4_ZavodskNomer_TB);
             this.Rashodomer4_GB.Controls.Add(this.label32);
-            this.Rashodomer4_GB.Enabled = false;
+            this.Rashodomer4_GB.Enabled = true;
             this.Rashodomer4_GB.Location = new System.Drawing.Point(467, 448);
             this.Rashodomer4_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer4_GB.Name = "Rashodomer4_GB";
             this.Rashodomer4_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer4_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer4_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer4_GB.TabIndex = 38;
             this.Rashodomer4_GB.TabStop = false;
             this.Rashodomer4_GB.Tag = "FirstFlowmeter";
@@ -728,7 +730,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label25.AutoSize = true;
             this.label25.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label25.Location = new System.Drawing.Point(20, -6);
+            this.label25.Location = new System.Drawing.Point(20, 0);
             this.label25.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(195, 29);
@@ -875,6 +877,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer5_GB
             // 
             this.Rashodomer5_GB.Controls.Add(this.label33);
+            this.Rashodomer5_GB.Controls.Add(this.Rashodomer5_CB);
             this.Rashodomer5_GB.Controls.Add(this.Flow5_Diameter_CB);
             this.Rashodomer5_GB.Controls.Add(this.label34);
             this.Rashodomer5_GB.Controls.Add(this.Flow5_GosReestr_CB);
@@ -889,12 +892,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer5_GB.Controls.Add(this.label39);
             this.Rashodomer5_GB.Controls.Add(this.Flow5_ZavodskNomer_TB);
             this.Rashodomer5_GB.Controls.Add(this.label40);
-            this.Rashodomer5_GB.Enabled = false;
+            this.Rashodomer5_GB.Enabled = true;
             this.Rashodomer5_GB.Location = new System.Drawing.Point(865, 139);
             this.Rashodomer5_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer5_GB.Name = "Rashodomer5_GB";
             this.Rashodomer5_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer5_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer5_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer5_GB.TabIndex = 37;
             this.Rashodomer5_GB.TabStop = false;
             this.Rashodomer5_GB.Tag = "FirstFlowmeter";
@@ -903,7 +906,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label33.AutoSize = true;
             this.label33.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label33.Location = new System.Drawing.Point(20, -6);
+            this.label33.Location = new System.Drawing.Point(20, 0);
             this.label33.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label33.Name = "label33";
             this.label33.Size = new System.Drawing.Size(195, 29);
@@ -1050,6 +1053,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // Rashodomer6_GB
             // 
             this.Rashodomer6_GB.Controls.Add(this.label41);
+            this.Rashodomer6_GB.Controls.Add(this.Rashodomer6_CB);
             this.Rashodomer6_GB.Controls.Add(this.Flow6_Diameter_CB);
             this.Rashodomer6_GB.Controls.Add(this.label42);
             this.Rashodomer6_GB.Controls.Add(this.Flow6_GosReestr_CB);
@@ -1064,12 +1068,12 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer6_GB.Controls.Add(this.label47);
             this.Rashodomer6_GB.Controls.Add(this.Flow6_ZavodskNomer_TB);
             this.Rashodomer6_GB.Controls.Add(this.label48);
-            this.Rashodomer6_GB.Enabled = false;
+            this.Rashodomer6_GB.Enabled = true;
             this.Rashodomer6_GB.Location = new System.Drawing.Point(865, 448);
             this.Rashodomer6_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer6_GB.Name = "Rashodomer6_GB";
             this.Rashodomer6_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Rashodomer6_GB.Size = new System.Drawing.Size(391, 272);
+            this.Rashodomer6_GB.Size = new System.Drawing.Size(391, 300);
             this.Rashodomer6_GB.TabIndex = 37;
             this.Rashodomer6_GB.TabStop = false;
             this.Rashodomer6_GB.Tag = "FirstFlowmeter";
@@ -1079,7 +1083,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.label41.AutoSize = true;
             this.label41.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label41.Location = new System.Drawing.Point(20, -6);
+            this.label41.Location = new System.Drawing.Point(20, 0);
             this.label41.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label41.Name = "label41";
             this.label41.Size = new System.Drawing.Size(195, 29);
@@ -1245,30 +1249,11 @@ namespace PoverkaWinForms.Forms.Verifier
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
-            // FlowmetersEnable_TB
-            // 
-            this.FlowmetersEnable_TB.Location = new System.Drawing.Point(1074, 92);
-            this.FlowmetersEnable_TB.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.FlowmetersEnable_TB.Name = "FlowmetersEnable_TB";
-            this.FlowmetersEnable_TB.Size = new System.Drawing.Size(177, 22);
-            this.FlowmetersEnable_TB.TabIndex = 36;
-            // 
-            // button2
-            // 
-            this.button2.Location = new System.Drawing.Point(971, 89);
-            this.button2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(100, 28);
-            this.button2.TabIndex = 44;
-            this.button2.Text = "Тест";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
-            // 
             // Rashodomer2_CB
             // 
             this.Rashodomer2_CB.AutoSize = true;
             this.Rashodomer2_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer2_CB.Location = new System.Drawing.Point(353, 432);
+            this.Rashodomer2_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer2_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer2_CB.Name = "Rashodomer2_CB";
             this.Rashodomer2_CB.Size = new System.Drawing.Size(102, 21);
@@ -1281,7 +1266,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Rashodomer3_CB.AutoSize = true;
             this.Rashodomer3_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer3_CB.Location = new System.Drawing.Point(751, 123);
+            this.Rashodomer3_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer3_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer3_CB.Name = "Rashodomer3_CB";
             this.Rashodomer3_CB.Size = new System.Drawing.Size(102, 21);
@@ -1294,7 +1279,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Rashodomer6_CB.AutoSize = true;
             this.Rashodomer6_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer6_CB.Location = new System.Drawing.Point(1149, 433);
+            this.Rashodomer6_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer6_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer6_CB.Name = "Rashodomer6_CB";
             this.Rashodomer6_CB.Size = new System.Drawing.Size(102, 21);
@@ -1307,7 +1292,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Rashodomer5_CB.AutoSize = true;
             this.Rashodomer5_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer5_CB.Location = new System.Drawing.Point(1151, 124);
+            this.Rashodomer5_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer5_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer5_CB.Name = "Rashodomer5_CB";
             this.Rashodomer5_CB.Size = new System.Drawing.Size(102, 21);
@@ -1320,7 +1305,7 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Rashodomer4_CB.AutoSize = true;
             this.Rashodomer4_CB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.Rashodomer4_CB.Location = new System.Drawing.Point(751, 432);
+            this.Rashodomer4_CB.Location = new System.Drawing.Point(260, 0);
             this.Rashodomer4_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer4_CB.Name = "Rashodomer4_CB";
             this.Rashodomer4_CB.Size = new System.Drawing.Size(102, 21);
@@ -1334,14 +1319,6 @@ namespace PoverkaWinForms.Forms.Verifier
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1323, 777);
-            this.Controls.Add(this.Rashodomer6_CB);
-            this.Controls.Add(this.Rashodomer5_CB);
-            this.Controls.Add(this.Rashodomer4_CB);
-            this.Controls.Add(this.Rashodomer3_CB);
-            this.Controls.Add(this.Rashodomer2_CB);
-            this.Controls.Add(this.Rashodomer1_CB);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.FlowmetersEnable_TB);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.Next_B);
             this.Controls.Add(this.Rashodomer6_GB);
@@ -1475,8 +1452,6 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label48;
         private System.Windows.Forms.Button Next_B;
         private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.TextBox FlowmetersEnable_TB;
-        private System.Windows.Forms.Button button2;
         private System.Windows.Forms.CheckBox Rashodomer1_CB;
         private System.Windows.Forms.CheckBox Rashodomer2_CB;
         private System.Windows.Forms.CheckBox Rashodomer3_CB;

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -250,7 +250,9 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow1_Name_SI_CB
             // 
-            this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow1_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow1_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow1_Name_SI_CB.FormattingEnabled = true;
             this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow1_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -258,6 +260,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow1_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow1_Name_SI_CB.TabIndex = 20;
             this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
+            this.Flow1_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // GosReestr
             // 
@@ -445,13 +448,16 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow2_Name_SI_CB
             // 
-            this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow2_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow2_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow2_Name_SI_CB.FormattingEnabled = true;
             this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow2_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
             this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow2_Name_SI_CB.TabIndex = 20;
+            this.Flow2_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // label13
             // 
@@ -622,13 +628,16 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow3_Name_SI_CB
             // 
-            this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow3_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow3_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow3_Name_SI_CB.FormattingEnabled = true;
             this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow3_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
             this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow3_Name_SI_CB.TabIndex = 20;
+            this.Flow3_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // label20
             // 
@@ -798,13 +807,16 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow4_Name_SI_CB
             // 
-            this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow4_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow4_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow4_Name_SI_CB.FormattingEnabled = true;
             this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow4_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
             this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow4_Name_SI_CB.TabIndex = 20;
+            this.Flow4_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // label28
             // 
@@ -974,13 +986,16 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow5_Name_SI_CB
             // 
-            this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow5_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow5_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow5_Name_SI_CB.FormattingEnabled = true;
             this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow5_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
             this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow5_Name_SI_CB.TabIndex = 20;
+            this.Flow5_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // label36
             // 
@@ -1151,13 +1166,16 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             // Flow6_Name_SI_CB
             // 
-            this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.Flow6_Name_SI_CB.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.Flow6_Name_SI_CB.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Flow6_Name_SI_CB.FormattingEnabled = true;
             this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow6_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
             this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow6_Name_SI_CB.TabIndex = 20;
+            this.Flow6_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             // 
             // label44
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -241,32 +241,32 @@ namespace PoverkaWinForms.Forms.Verifier
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(20, 75);
+            this.label2.Location = new System.Drawing.Point(20, 43);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(32, 16);
-            this.label2.TabIndex = 23;
+            this.label2.TabIndex = 21;
             this.label2.Text = "Тип";
             // 
             // Flow1_Name_SI_CB
             // 
             this.Flow1_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow1_Name_SI_CB.FormattingEnabled = true;
-            this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow1_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow1_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow1_Name_SI_CB.Name = "Flow1_Name_SI_CB";
             this.Flow1_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_Name_SI_CB.TabIndex = 22;
+            this.Flow1_Name_SI_CB.TabIndex = 20;
             this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
             // 
             // GosReestr
             // 
             this.GosReestr.AutoSize = true;
-            this.GosReestr.Location = new System.Drawing.Point(20, 43);
+            this.GosReestr.Location = new System.Drawing.Point(20, 75);
             this.GosReestr.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.GosReestr.Name = "GosReestr";
             this.GosReestr.Size = new System.Drawing.Size(111, 16);
-            this.GosReestr.TabIndex = 21;
+            this.GosReestr.TabIndex = 23;
             this.GosReestr.Text = "Производитель";
             // 
             // Flow1_GosReestr_CB
@@ -275,11 +275,11 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow1_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow1_GosReestr_CB.FormattingEnabled = true;
             this.Flow1_GosReestr_CB.IntegralHeight = false;
-            this.Flow1_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow1_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow1_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow1_GosReestr_CB.Name = "Flow1_GosReestr_CB";
             this.Flow1_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow1_GosReestr_CB.TabIndex = 20;
+            this.Flow1_GosReestr_CB.TabIndex = 22;
             this.Flow1_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.GosReestrCB_SelectedIndexChanged);
             // 
             // label1
@@ -408,11 +408,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow2_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow2_GosReestr_CB.FormattingEnabled = true;
-            this.Flow2_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow2_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow2_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow2_GosReestr_CB.Name = "Flow2_GosReestr_CB";
             this.Flow2_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_GosReestr_CB.TabIndex = 20;
+            this.Flow2_GosReestr_CB.TabIndex = 22;
             this.Flow2_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow2_GosReestr_CB_SelectedIndexChanged);
             // 
             // Flow2_Document_CB
@@ -426,13 +426,13 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow2_Document_CB.TabIndex = 32;
             // 
             // label12
-            // 
+            //
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(20, 43);
+            this.label12.Location = new System.Drawing.Point(20, 75);
             this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(111, 16);
-            this.label12.TabIndex = 21;
+            this.label12.TabIndex = 23;
             this.label12.Text = "Производитель";
             // 
             // Flow2_WeightImpulse_TB
@@ -447,11 +447,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow2_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow2_Name_SI_CB.FormattingEnabled = true;
-            this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow2_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow2_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
             this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow2_Name_SI_CB.TabIndex = 22;
+            this.Flow2_Name_SI_CB.TabIndex = 20;
             // 
             // label13
             // 
@@ -466,11 +466,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(20, 75);
+            this.label14.Location = new System.Drawing.Point(20, 43);
             this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label14.Name = "label14";
             this.label14.Size = new System.Drawing.Size(32, 16);
-            this.label14.TabIndex = 23;
+            this.label14.TabIndex = 21;
             this.label14.Text = "Тип";
             this.label14.Click += new System.EventHandler(this.label14_Click);
             // 
@@ -585,11 +585,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow3_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow3_GosReestr_CB.FormattingEnabled = true;
-            this.Flow3_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow3_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow3_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow3_GosReestr_CB.Name = "Flow3_GosReestr_CB";
             this.Flow3_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_GosReestr_CB.TabIndex = 20;
+            this.Flow3_GosReestr_CB.TabIndex = 22;
             this.Flow3_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow3_GosReestr_CB_SelectedIndexChanged);
             // 
             // Flow3_Document_CB
@@ -603,13 +603,13 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow3_Document_CB.TabIndex = 32;
             // 
             // label19
-            // 
+            //
             this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(20, 43);
+            this.label19.Location = new System.Drawing.Point(20, 75);
             this.label19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(111, 16);
-            this.label19.TabIndex = 21;
+            this.label19.TabIndex = 23;
             this.label19.Text = "Производитель";
             // 
             // Flow3_WeightImpulse_TB
@@ -624,11 +624,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow3_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow3_Name_SI_CB.FormattingEnabled = true;
-            this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow3_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow3_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
             this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow3_Name_SI_CB.TabIndex = 22;
+            this.Flow3_Name_SI_CB.TabIndex = 20;
             // 
             // label20
             // 
@@ -643,11 +643,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label21
             // 
             this.label21.AutoSize = true;
-            this.label21.Location = new System.Drawing.Point(20, 75);
+            this.label21.Location = new System.Drawing.Point(20, 43);
             this.label21.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(32, 16);
-            this.label21.TabIndex = 23;
+            this.label21.TabIndex = 21;
             this.label21.Text = "Тип";
             // 
             // label22
@@ -758,14 +758,14 @@ namespace PoverkaWinForms.Forms.Verifier
             this.label26.Text = "Документ на поверку";
             // 
             // Flow4_GosReestr_CB
-            // 
+            //
             this.Flow4_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow4_GosReestr_CB.FormattingEnabled = true;
-            this.Flow4_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow4_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow4_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow4_GosReestr_CB.Name = "Flow4_GosReestr_CB";
             this.Flow4_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_GosReestr_CB.TabIndex = 20;
+            this.Flow4_GosReestr_CB.TabIndex = 22;
             this.Flow4_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow4_GosReestr_CB_SelectedIndexChanged);
             // 
             // Flow4_Document_CB
@@ -781,11 +781,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label27
             // 
             this.label27.AutoSize = true;
-            this.label27.Location = new System.Drawing.Point(20, 43);
+            this.label27.Location = new System.Drawing.Point(20, 75);
             this.label27.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label27.Name = "label27";
             this.label27.Size = new System.Drawing.Size(111, 16);
-            this.label27.TabIndex = 21;
+            this.label27.TabIndex = 23;
             this.label27.Text = "Производитель";
             // 
             // Flow4_WeightImpulse_TB
@@ -800,11 +800,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow4_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow4_Name_SI_CB.FormattingEnabled = true;
-            this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow4_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow4_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
             this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow4_Name_SI_CB.TabIndex = 22;
+            this.Flow4_Name_SI_CB.TabIndex = 20;
             // 
             // label28
             // 
@@ -819,11 +819,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label29
             // 
             this.label29.AutoSize = true;
-            this.label29.Location = new System.Drawing.Point(20, 75);
+            this.label29.Location = new System.Drawing.Point(20, 43);
             this.label29.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label29.Name = "label29";
             this.label29.Size = new System.Drawing.Size(136, 16);
-            this.label29.TabIndex = 23;
+            this.label29.TabIndex = 21;
             this.label29.Text = "Наиименование СИ";
             // 
             // label30
@@ -934,14 +934,14 @@ namespace PoverkaWinForms.Forms.Verifier
             this.label34.Text = "Документ на поверку";
             // 
             // Flow5_GosReestr_CB
-            // 
+            //
             this.Flow5_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow5_GosReestr_CB.FormattingEnabled = true;
-            this.Flow5_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow5_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow5_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow5_GosReestr_CB.Name = "Flow5_GosReestr_CB";
             this.Flow5_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_GosReestr_CB.TabIndex = 20;
+            this.Flow5_GosReestr_CB.TabIndex = 22;
             this.Flow5_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow5_GosReestr_CB_SelectedIndexChanged);
             // 
             // Flow5_Document_CB
@@ -957,11 +957,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label35
             // 
             this.label35.AutoSize = true;
-            this.label35.Location = new System.Drawing.Point(20, 43);
+            this.label35.Location = new System.Drawing.Point(20, 75);
             this.label35.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label35.Name = "label35";
             this.label35.Size = new System.Drawing.Size(111, 16);
-            this.label35.TabIndex = 21;
+            this.label35.TabIndex = 23;
             this.label35.Text = "Производитель";
             // 
             // Flow5_WeightImpulse_TB
@@ -976,11 +976,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow5_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow5_Name_SI_CB.FormattingEnabled = true;
-            this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow5_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow5_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
             this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow5_Name_SI_CB.TabIndex = 22;
+            this.Flow5_Name_SI_CB.TabIndex = 20;
             // 
             // label36
             // 
@@ -995,11 +995,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label37
             // 
             this.label37.AutoSize = true;
-            this.label37.Location = new System.Drawing.Point(20, 75);
+            this.label37.Location = new System.Drawing.Point(20, 43);
             this.label37.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label37.Name = "label37";
             this.label37.Size = new System.Drawing.Size(32, 16);
-            this.label37.TabIndex = 23;
+            this.label37.TabIndex = 21;
             this.label37.Text = "Тип";
             // 
             // label38
@@ -1111,14 +1111,14 @@ namespace PoverkaWinForms.Forms.Verifier
             this.label42.Text = "Документ на поверку";
             // 
             // Flow6_GosReestr_CB
-            // 
+            //
             this.Flow6_GosReestr_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow6_GosReestr_CB.FormattingEnabled = true;
-            this.Flow6_GosReestr_CB.Location = new System.Drawing.Point(192, 41);
+            this.Flow6_GosReestr_CB.Location = new System.Drawing.Point(192, 71);
             this.Flow6_GosReestr_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow6_GosReestr_CB.Name = "Flow6_GosReestr_CB";
             this.Flow6_GosReestr_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_GosReestr_CB.TabIndex = 20;
+            this.Flow6_GosReestr_CB.TabIndex = 22;
             this.Flow6_GosReestr_CB.SelectedIndexChanged += new System.EventHandler(this.Flow6_GosReestr_CB_SelectedIndexChanged);
             // 
             // Flow6_Document_CB
@@ -1134,11 +1134,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label43
             // 
             this.label43.AutoSize = true;
-            this.label43.Location = new System.Drawing.Point(20, 43);
+            this.label43.Location = new System.Drawing.Point(20, 75);
             this.label43.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label43.Name = "label43";
             this.label43.Size = new System.Drawing.Size(111, 16);
-            this.label43.TabIndex = 21;
+            this.label43.TabIndex = 23;
             this.label43.Text = "Производитель";
             // 
             // Flow6_WeightImpulse_TB
@@ -1153,11 +1153,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             this.Flow6_Name_SI_CB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Flow6_Name_SI_CB.FormattingEnabled = true;
-            this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 71);
+            this.Flow6_Name_SI_CB.Location = new System.Drawing.Point(192, 41);
             this.Flow6_Name_SI_CB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
             this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
-            this.Flow6_Name_SI_CB.TabIndex = 22;
+            this.Flow6_Name_SI_CB.TabIndex = 20;
             // 
             // label44
             // 
@@ -1172,11 +1172,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // label45
             // 
             this.label45.AutoSize = true;
-            this.label45.Location = new System.Drawing.Point(20, 75);
+            this.label45.Location = new System.Drawing.Point(20, 43);
             this.label45.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label45.Name = "label45";
             this.label45.Size = new System.Drawing.Size(32, 16);
-            this.label45.TabIndex = 23;
+            this.label45.TabIndex = 21;
             this.label45.Text = "Тип";
             // 
             // label46

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -312,7 +312,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer1_GB.Controls.Add(this.Flow1_ZavodskNomer_TB);
             this.Rashodomer1_GB.Controls.Add(this.label4);
             this.Rashodomer1_GB.Enabled = true;
-            this.Rashodomer1_GB.Location = new System.Drawing.Point(68, 139);
+            this.Rashodomer1_GB.Location = new System.Drawing.Point(68, 60);
             this.Rashodomer1_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer1_GB.Name = "Rashodomer1_GB";
             this.Rashodomer1_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -364,7 +364,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer2_GB.Controls.Add(this.Flow2_ZavodskNomer_TB);
             this.Rashodomer2_GB.Controls.Add(this.label17);
             this.Rashodomer2_GB.Enabled = true;
-            this.Rashodomer2_GB.Location = new System.Drawing.Point(68, 448);
+            this.Rashodomer2_GB.Location = new System.Drawing.Point(68, 369);
             this.Rashodomer2_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer2_GB.Name = "Rashodomer2_GB";
             this.Rashodomer2_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -541,7 +541,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer3_GB.Controls.Add(this.Flow3_ZavodskNomer_TB);
             this.Rashodomer3_GB.Controls.Add(this.label24);
             this.Rashodomer3_GB.Enabled = true;
-            this.Rashodomer3_GB.Location = new System.Drawing.Point(467, 139);
+            this.Rashodomer3_GB.Location = new System.Drawing.Point(467, 60);
             this.Rashodomer3_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer3_GB.Name = "Rashodomer3_GB";
             this.Rashodomer3_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -717,7 +717,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer4_GB.Controls.Add(this.Flow4_ZavodskNomer_TB);
             this.Rashodomer4_GB.Controls.Add(this.label32);
             this.Rashodomer4_GB.Enabled = true;
-            this.Rashodomer4_GB.Location = new System.Drawing.Point(467, 448);
+            this.Rashodomer4_GB.Location = new System.Drawing.Point(467, 369);
             this.Rashodomer4_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer4_GB.Name = "Rashodomer4_GB";
             this.Rashodomer4_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -893,7 +893,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer5_GB.Controls.Add(this.Flow5_ZavodskNomer_TB);
             this.Rashodomer5_GB.Controls.Add(this.label40);
             this.Rashodomer5_GB.Enabled = true;
-            this.Rashodomer5_GB.Location = new System.Drawing.Point(865, 139);
+            this.Rashodomer5_GB.Location = new System.Drawing.Point(865, 60);
             this.Rashodomer5_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer5_GB.Name = "Rashodomer5_GB";
             this.Rashodomer5_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -1069,7 +1069,7 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Rashodomer6_GB.Controls.Add(this.Flow6_ZavodskNomer_TB);
             this.Rashodomer6_GB.Controls.Add(this.label48);
             this.Rashodomer6_GB.Enabled = true;
-            this.Rashodomer6_GB.Location = new System.Drawing.Point(865, 448);
+            this.Rashodomer6_GB.Location = new System.Drawing.Point(865, 369);
             this.Rashodomer6_GB.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Rashodomer6_GB.Name = "Rashodomer6_GB";
             this.Rashodomer6_GB.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -260,8 +260,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow1_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow1_Name_SI_CB.TabIndex = 20;
             this.Flow1_Name_SI_CB.SelectedIndexChanged += new System.EventHandler(this.Flow1_Name_SI_CB_SelectedIndexChanged);
-            this.Flow1_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow1_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow1_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow1_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // GosReestr
@@ -459,8 +459,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
             this.Flow2_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow2_Name_SI_CB.TabIndex = 20;
-            this.Flow2_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow2_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow2_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow2_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label13
@@ -641,8 +641,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
             this.Flow3_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow3_Name_SI_CB.TabIndex = 20;
-            this.Flow3_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow3_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow3_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow3_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label20
@@ -822,8 +822,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
             this.Flow4_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow4_Name_SI_CB.TabIndex = 20;
-            this.Flow4_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow4_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow4_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow4_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label28
@@ -1003,8 +1003,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
             this.Flow5_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow5_Name_SI_CB.TabIndex = 20;
-            this.Flow5_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow5_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow5_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow5_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label36
@@ -1185,8 +1185,8 @@ namespace PoverkaWinForms.Forms.Verifier
             this.Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
             this.Flow6_Name_SI_CB.Size = new System.Drawing.Size(177, 24);
             this.Flow6_Name_SI_CB.TabIndex = 20;
-            this.Flow6_Name_SI_CB.TextChanged += new System.EventHandler(this.MeterTypeCB_TextChanged);
             this.Flow6_Name_SI_CB.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyDown);
+            this.Flow6_Name_SI_CB.KeyUp += new System.Windows.Forms.KeyEventHandler(this.MeterTypeCB_KeyUp);
             this.Flow6_Name_SI_CB.Click += new System.EventHandler(this.MeterTypeCB_Click);
             // 
             // label44

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -27,9 +27,9 @@ namespace PoverkaWinForms.Forms.Verifier
         _meterTypeService = meterTypeService;
     }
 
-        private void MetersSetupForm_Load(object sender, EventArgs e)
+        private async void MetersSetupForm_Load(object sender, EventArgs e)
         {
-            // TODO: добавить логику загрузки при необходимости
+            await _meterTypeService.GetAllAsync(string.Empty, 10);
         }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -77,7 +77,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer1_GB, Rashodomer1_CB, label8);
             if (Rashodomer1_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty);
             }
         }
 
@@ -86,7 +86,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer2_GB, Rashodomer2_CB, label10);
             if (Rashodomer2_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty);
             }
         }
 
@@ -95,7 +95,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer3_GB, Rashodomer3_CB, label9);
             if (Rashodomer3_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty);
             }
         }
 
@@ -104,7 +104,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer6_GB, Rashodomer6_CB, label41);
             if (Rashodomer6_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty);
             }
         }
 
@@ -113,7 +113,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer5_GB, Rashodomer5_CB, label33);
             if (Rashodomer5_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty);
             }
         }
 
@@ -122,7 +122,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer4_GB, Rashodomer4_CB, label25);
             if (Rashodomer4_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, limit: 10);
+                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty);
             }
         }
         private void groupBox6_Enter(object sender, EventArgs e)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -70,7 +70,6 @@ namespace PoverkaWinForms.Forms.Verifier
         private static void ToggleGroupControls(GroupBox groupBox, CheckBox checkBox, Label caption)
         {
             bool visible = checkBox.Checked;
-            checkBox.Text = visible ? "Выключить" : "Включить";
 
             foreach (Control control in groupBox.Controls)
             {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -60,6 +60,12 @@ namespace PoverkaWinForms.Forms.Verifier
             if (_updating || sender is not ComboBox combo)
                 return;
 
+            if (combo.SelectedIndex >= 0)
+            {
+                combo.DroppedDown = false;
+                return;
+            }
+
             await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -77,7 +83,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer1_GB, Rashodomer1_CB, label8);
             if (Rashodomer1_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, 10);
             }
         }
 
@@ -86,7 +92,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer2_GB, Rashodomer2_CB, label10);
             if (Rashodomer2_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, 10);
             }
         }
 
@@ -95,7 +101,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer3_GB, Rashodomer3_CB, label9);
             if (Rashodomer3_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, 10);
             }
         }
 
@@ -104,7 +110,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer6_GB, Rashodomer6_CB, label41);
             if (Rashodomer6_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, 10);
             }
         }
 
@@ -113,7 +119,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer5_GB, Rashodomer5_CB, label33);
             if (Rashodomer5_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, 10);
             }
         }
 
@@ -122,7 +128,7 @@ namespace PoverkaWinForms.Forms.Verifier
             ToggleGroupControls(Rashodomer4_GB, Rashodomer4_CB, label25);
             if (Rashodomer4_CB.Checked)
             {
-                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty);
+                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, 10);
             }
         }
         private void groupBox6_Enter(object sender, EventArgs e)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -50,19 +50,20 @@ namespace PoverkaWinForms.Forms.Verifier
             combo.ValueMember = nameof(MeterTypeDto.Id);
             combo.SelectedIndex = -1;
             combo.Text = search;
+            combo.SelectedIndex = -1;
             combo.SelectionStart = selStart;
             combo.SelectionLength = 0;
             combo.EndUpdate();
             _typedTexts[combo] = search;
-            _updating = false;
 
             if (dropDown)
             {
                 combo.DroppedDown = true;
-                combo.SelectedIndex = -1;
                 Cursor.Current = Cursors.Default;
                 Cursor.Show();
             }
+
+            _updating = false;
         }
 
         private async void MeterTypeCB_TextChanged(object? sender, EventArgs e)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Windows.Forms;
+using System.Threading.Tasks;
 using PoverkaWinForms.Services;
 using PoverkaWinForms.Settings;
 
@@ -41,17 +42,17 @@ namespace PoverkaWinForms.Forms.Verifier
         }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
-        private async void MeterTypeCB_TextChanged(object? sender, EventArgs e)
-        {
-            if (_updating || sender is not ComboBox combo)
-                return;
 
+        private async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
+        {
             var token = await _tokens.GetAccessTokenAsync();
             if (token is null)
                 return;
 
-            var text = combo.Text;
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/api/metertypes?search={Uri.EscapeDataString(text)}");
+            var url = string.IsNullOrWhiteSpace(search)
+                ? "/api/metertypes"
+                : $"/api/metertypes?search={Uri.EscapeDataString(search)}";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             var response = await _http.SendAsync(request);
             if (!response.IsSuccessStatusCode)
@@ -61,19 +62,32 @@ namespace PoverkaWinForms.Forms.Verifier
             if (items is null)
                 return;
 
+            if (limit.HasValue)
+                items = items.Take(limit.Value).ToList();
+
             var selStart = combo.SelectionStart;
             _updating = true;
             combo.BeginUpdate();
             combo.DataSource = items;
             combo.DisplayMember = nameof(MeterTypeDto.Type);
             combo.ValueMember = nameof(MeterTypeDto.Id);
-            combo.DroppedDown = true;
             combo.SelectedIndex = -1;
-            combo.Text = text;
+            combo.Text = search;
             combo.SelectionStart = selStart;
             combo.SelectionLength = 0;
             combo.EndUpdate();
             _updating = false;
+
+            if (dropDown)
+                combo.DroppedDown = true;
+        }
+
+        private async void MeterTypeCB_TextChanged(object? sender, EventArgs e)
+        {
+            if (_updating || sender is not ComboBox combo)
+                return;
+
+            await PopulateMeterTypesAsync(combo, combo.Text, dropDown: true);
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
         private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -85,34 +99,58 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Next_B_Click(object sender, EventArgs e) { }
         private void button1_Click(object sender, EventArgs e) { }
 
-        private void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer1_GB, Rashodomer1_CB, label8);
+            if (Rashodomer1_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
 
-        private void Rashodomer2_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer2_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer2_GB, Rashodomer2_CB, label10);
+            if (Rashodomer2_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
 
-        private void Rashodomer3_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer3_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer3_GB, Rashodomer3_CB, label9);
+            if (Rashodomer3_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
 
-        private void Rashodomer6_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer6_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer6_GB, Rashodomer6_CB, label41);
+            if (Rashodomer6_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
 
-        private void Rashodomer5_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer5_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer5_GB, Rashodomer5_CB, label33);
+            if (Rashodomer5_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
 
-        private void Rashodomer4_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void Rashodomer4_CB_CheckedChanged(object? sender, EventArgs e)
         {
             ToggleGroupControls(Rashodomer4_GB, Rashodomer4_CB, label25);
+            if (Rashodomer4_CB.Checked)
+            {
+                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, limit: 10);
+            }
         }
         private void groupBox6_Enter(object sender, EventArgs e)
         {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -8,6 +8,13 @@ namespace PoverkaWinForms.Forms.Verifier
         public MetersSetupForm()
         {
             InitializeComponent();
+
+            Rashodomer1_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer2_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer3_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer4_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer5_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
         }
 
         private void MetersSetupForm_Load(object sender, EventArgs e)
@@ -25,46 +32,53 @@ namespace PoverkaWinForms.Forms.Verifier
         private void label14_Click(object sender, EventArgs e) { }
         private void Next_B_Click(object sender, EventArgs e) { }
         private void button1_Click(object sender, EventArgs e) { }
-        private void button2_Click(object sender, EventArgs e) { }
 
-        private void Rashodomer1_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer1_GB.Enabled = Rashodomer1_CB.Checked;
-            Rashodomer1_CB.Text = Rashodomer1_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer1_GB, Rashodomer1_CB, label8);
         }
 
-        private void Rashodomer2_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer2_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer2_GB.Enabled = Rashodomer2_CB.Checked;
-            Rashodomer2_CB.Text = Rashodomer2_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer2_GB, Rashodomer2_CB, label10);
         }
 
-        private void Rashodomer3_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer3_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer3_GB.Enabled = Rashodomer3_CB.Checked;
-            Rashodomer3_CB.Text = Rashodomer3_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer3_GB, Rashodomer3_CB, label9);
         }
 
-        private void Rashodomer6_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer6_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer6_GB.Enabled = Rashodomer6_CB.Checked;
-            Rashodomer6_CB.Text = Rashodomer6_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer6_GB, Rashodomer6_CB, label41);
         }
 
-        private void Rashodomer5_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer5_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer5_GB.Enabled = Rashodomer5_CB.Checked;
-            Rashodomer5_CB.Text = Rashodomer5_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer5_GB, Rashodomer5_CB, label33);
         }
 
-        private void Rashodomer4_CB_CheckedChanged(object sender, EventArgs e)
+        private void Rashodomer4_CB_CheckedChanged(object? sender, EventArgs e)
         {
-            Rashodomer4_GB.Enabled = Rashodomer4_CB.Checked;
-            Rashodomer4_CB.Text = Rashodomer4_CB.Checked ? "Выключить" : "Включить";
+            ToggleGroupControls(Rashodomer4_GB, Rashodomer4_CB, label25);
         }
         private void groupBox6_Enter(object sender, EventArgs e)
         {
             // TODO: добавить логику обработки при необходимости
+        }
+
+        private static void ToggleGroupControls(GroupBox groupBox, CheckBox checkBox, Label caption)
+        {
+            bool visible = checkBox.Checked;
+            checkBox.Text = visible ? "Выключить" : "Включить";
+
+            foreach (Control control in groupBox.Controls)
+            {
+                if (control != caption && control != checkBox)
+                {
+                    control.Visible = visible;
+                }
+            }
         }
     }
 }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -130,6 +130,10 @@ namespace PoverkaWinForms.Forms.Verifier
                 e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
                 return;
 
+            var keyChar = (char)e.KeyValue;
+            if (!char.IsLetter(keyChar) && e.KeyCode != Keys.Back && e.KeyCode != Keys.Delete)
+                return;
+
             _typedTexts[combo] = combo.Text;
 
             if (_searchTokens.TryGetValue(combo, out var prev))

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Windows.Forms;
 using System.Threading.Tasks;
 using PoverkaWinForms.Services;
@@ -37,9 +36,7 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
         {
-            var items = await _meterTypeService.GetAllAsync(search);
-            if (limit.HasValue)
-                items = items.Take(limit.Value).ToList();
+            var items = await _meterTypeService.GetAllAsync(search, limit);
 
             var selStart = combo.SelectionStart;
             _updating = true;
@@ -63,7 +60,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (_updating || sender is not ComboBox combo)
                 return;
 
-            await PopulateMeterTypesAsync(combo, combo.Text, dropDown: true);
+            await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
         private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -52,7 +52,12 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
 
             if (dropDown)
+            {
                 combo.DroppedDown = true;
+                combo.SelectedIndex = -1;
+                Cursor.Current = Cursors.Default;
+                Cursor.Show();
+            }
         }
 
         private async void MeterTypeCB_TextChanged(object? sender, EventArgs e)
@@ -67,6 +72,15 @@ namespace PoverkaWinForms.Forms.Verifier
             }
 
             await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
+        }
+
+        private void MeterTypeCB_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && sender is ComboBox combo && combo.SelectedIndex == -1)
+            {
+                e.Handled = true;
+                combo.DroppedDown = false;
+            }
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
         private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -50,7 +50,6 @@ namespace PoverkaWinForms.Forms.Verifier
             combo.ValueMember = nameof(MeterTypeDto.Id);
             combo.SelectedIndex = -1;
             combo.Text = search;
-            combo.SelectedIndex = -1;
             combo.SelectionStart = selStart;
             combo.SelectionLength = 0;
             combo.EndUpdate();
@@ -157,8 +156,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo)
             {
                 combo.SelectionLength = 0;
-                await PopulateMeterTypesAsync(combo, combo.Text,
-                    combo.Text.Length > 0 ? 20 : 10, dropDown: true);
+                await PopulateMeterTypesAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
             }
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -66,39 +66,13 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        private async void MeterTypeCB_TextChanged(object? sender, EventArgs e)
-        {
-            if (_updating || sender is not ComboBox combo)
-                return;
-
-            if (combo.SelectedIndex >= 0)
-            {
-                combo.DroppedDown = false;
-                return;
-            }
-
-            _typedTexts[combo] = combo.Text;
-
-            if (_searchTokens.TryGetValue(combo, out var prev))
-                prev.Cancel();
-
-            var cts = new CancellationTokenSource();
-            _searchTokens[combo] = cts;
-
-            try
-            {
-                await Task.Delay(300, cts.Token);
-                await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
-            }
-            catch (TaskCanceledException)
-            {
-            }
-        }
-
         private void MeterTypeCB_KeyDown(object? sender, KeyEventArgs e)
         {
             if (sender is not ComboBox combo)
                 return;
+
+            if (_searchTokens.TryGetValue(combo, out var prev))
+                prev.Cancel();
 
             if (e.KeyCode == Keys.Enter)
             {
@@ -147,11 +121,40 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void MeterTypeCB_Click(object? sender, EventArgs e)
+        private async void MeterTypeCB_KeyUp(object? sender, KeyEventArgs e)
+        {
+            if (_updating || sender is not ComboBox combo)
+                return;
+
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down ||
+                e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+                return;
+
+            _typedTexts[combo] = combo.Text;
+
+            if (_searchTokens.TryGetValue(combo, out var prev))
+                prev.Cancel();
+
+            var cts = new CancellationTokenSource();
+            _searchTokens[combo] = cts;
+
+            try
+            {
+                await Task.Delay(300, cts.Token);
+                await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+
+        private async void MeterTypeCB_Click(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo)
             {
                 combo.SelectionLength = 0;
+                await PopulateMeterTypesAsync(combo, combo.Text,
+                    combo.Text.Length > 0 ? 20 : 10, dropDown: true);
             }
         }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -33,6 +33,7 @@ namespace PoverkaWinForms
                 .AddHttpMessageHandler<HttpErrorHandler>();
             services.AddTransient<UserService>();
             services.AddTransient<MeterImportService>();
+            services.AddTransient<MeterTypeService>();
 
             services.AddScoped<MetersSetupForm>();
             services.AddScoped<ConfigurationForm>();

--- a/Client/Services/MeterTypeService.cs
+++ b/Client/Services/MeterTypeService.cs
@@ -27,7 +27,6 @@ public class MeterTypeService
         {
             if (_defaultTypes.Count > 0)
                 return _defaultTypes;
-            take ??= 10;
         }
 
         var token = await _tokens.GetAccessTokenAsync();

--- a/Client/Services/MeterTypeService.cs
+++ b/Client/Services/MeterTypeService.cs
@@ -20,14 +20,22 @@ public class MeterTypeService
         _tokens = tokens;
     }
 
-    public async Task<List<MeterTypeDto>> GetAllAsync(string search)
+    public async Task<List<MeterTypeDto>> GetAllAsync(string search, int? take = null)
     {
         var token = await _tokens.GetAccessTokenAsync();
         if (token is null) return new();
 
-        var url = string.IsNullOrWhiteSpace(search)
-            ? "/api/metertypes"
-            : $"/api/metertypes?search={Uri.EscapeDataString(search)}";
+        var url = "/api/metertypes";
+        if (!string.IsNullOrWhiteSpace(search) || take.HasValue)
+        {
+            var query = new List<string>();
+            if (!string.IsNullOrWhiteSpace(search))
+                query.Add($"search={Uri.EscapeDataString(search)}");
+            if (take.HasValue)
+                query.Add($"take={take.Value}");
+            url += "?" + string.Join("&", query);
+        }
+
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var response = await _http.SendAsync(request);

--- a/Client/Services/MeterTypeService.cs
+++ b/Client/Services/MeterTypeService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using PoverkaWinForms.Settings;
+
+namespace PoverkaWinForms.Services;
+
+public class MeterTypeService
+{
+    private readonly HttpClient _http;
+    private readonly TokenService _tokens;
+
+    public MeterTypeService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
+    {
+        _http = factory.CreateClient("ApiClient");
+        _http.BaseAddress = new Uri(settings.Authority);
+        _tokens = tokens;
+    }
+
+    public async Task<List<MeterTypeDto>> GetAllAsync(string search)
+    {
+        var token = await _tokens.GetAccessTokenAsync();
+        if (token is null) return new();
+
+        var url = string.IsNullOrWhiteSpace(search)
+            ? "/api/metertypes"
+            : $"/api/metertypes?search={Uri.EscapeDataString(search)}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        if (!response.IsSuccessStatusCode) return new();
+
+        var items = await response.Content.ReadFromJsonAsync<List<MeterTypeDto>>();
+        return items ?? new();
+    }
+}
+
+public record MeterTypeDto(int Id, string Type, string FullName);

--- a/Client/Services/MeterTypeService.cs
+++ b/Client/Services/MeterTypeService.cs
@@ -12,6 +12,7 @@ public class MeterTypeService
 {
     private readonly HttpClient _http;
     private readonly TokenService _tokens;
+    private List<MeterTypeDto> _defaultTypes = new();
 
     public MeterTypeService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
     {
@@ -22,6 +23,13 @@ public class MeterTypeService
 
     public async Task<List<MeterTypeDto>> GetAllAsync(string search, int? take = null)
     {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            if (_defaultTypes.Count > 0)
+                return _defaultTypes;
+            take ??= 10;
+        }
+
         var token = await _tokens.GetAccessTokenAsync();
         if (token is null) return new();
 
@@ -42,7 +50,12 @@ public class MeterTypeService
         if (!response.IsSuccessStatusCode) return new();
 
         var items = await response.Content.ReadFromJsonAsync<List<MeterTypeDto>>();
-        return items ?? new();
+        items ??= new();
+
+        if (string.IsNullOrWhiteSpace(search))
+            _defaultTypes = items;
+
+        return items;
     }
 }
 

--- a/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
+++ b/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
@@ -25,9 +25,7 @@ public static class MeterTypeEndpoints
 
     private static async Task<Ok<IEnumerable<MeterTypeResponse>>> GetMeterTypes(string? search, MeterTypeService service)
     {
-        var items = string.IsNullOrWhiteSpace(search)
-            ? await service.GetAllAsync()
-            : await service.SearchAsync(search);
+        var items = await service.GetAllAsync(search);
         return TypedResults.Ok(items.Select(m => new MeterTypeResponse(m)));
     }
 

--- a/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
+++ b/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
@@ -23,9 +23,11 @@ public static class MeterTypeEndpoints
         return app;
     }
 
-    private static async Task<Ok<IEnumerable<MeterTypeResponse>>> GetMeterTypes(MeterTypeService service)
+    private static async Task<Ok<IEnumerable<MeterTypeResponse>>> GetMeterTypes(string? search, MeterTypeService service)
     {
-        var items = await service.GetAllAsync();
+        var items = string.IsNullOrWhiteSpace(search)
+            ? await service.GetAllAsync()
+            : await service.SearchAsync(search);
         return TypedResults.Ok(items.Select(m => new MeterTypeResponse(m)));
     }
 

--- a/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
+++ b/Server/Endpoints/MeterTypes/MeterTypeEndpoints.cs
@@ -23,9 +23,9 @@ public static class MeterTypeEndpoints
         return app;
     }
 
-    private static async Task<Ok<IEnumerable<MeterTypeResponse>>> GetMeterTypes(string? search, MeterTypeService service)
+    private static async Task<Ok<IEnumerable<MeterTypeResponse>>> GetMeterTypes(string? search, int? take, MeterTypeService service)
     {
-        var items = await service.GetAllAsync(search);
+        var items = await service.GetAllAsync(search, take);
         return TypedResults.Ok(items.Select(m => new MeterTypeResponse(m)));
     }
 

--- a/Server/Services/MeterTypeService.cs
+++ b/Server/Services/MeterTypeService.cs
@@ -13,7 +13,7 @@ public class MeterTypeService
         _db = db;
     }
 
-    public Task<List<MeterType>> GetAllAsync(string? search = null)
+    public Task<List<MeterType>> GetAllAsync(string? search = null, int? take = null)
     {
         IQueryable<MeterType> query = _db.MeterTypes;
 
@@ -21,6 +21,11 @@ public class MeterTypeService
         {
             var pattern = $"%{search}%";
             query = query.Where(m => EF.Functions.ILike(m.Type, pattern));
+        }
+
+        if (take.HasValue)
+        {
+            query = query.Take(take.Value);
         }
 
         return query.OrderBy(m => m.Type).ToListAsync();

--- a/Server/Services/MeterTypeService.cs
+++ b/Server/Services/MeterTypeService.cs
@@ -15,6 +15,16 @@ public class MeterTypeService
 
     public Task<List<MeterType>> GetAllAsync() => _db.MeterTypes.ToListAsync();
 
+    public Task<List<MeterType>> SearchAsync(string search)
+    {
+        var pattern = $"%{search}%";
+        return _db.MeterTypes
+            .Where(m => EF.Functions.ILike(m.Type, pattern) || EF.Functions.ILike(m.FullName, pattern))
+            .OrderBy(m => m.Type)
+            .Take(20)
+            .ToListAsync();
+    }
+
     public Task<MeterType?> GetAsync(int id) => _db.MeterTypes.FindAsync(id).AsTask();
 
     public async Task<MeterType> CreateAsync(string editorName, string type, string fullName)

--- a/Server/Services/MeterTypeService.cs
+++ b/Server/Services/MeterTypeService.cs
@@ -13,16 +13,17 @@ public class MeterTypeService
         _db = db;
     }
 
-    public Task<List<MeterType>> GetAllAsync() => _db.MeterTypes.ToListAsync();
-
-    public Task<List<MeterType>> SearchAsync(string search)
+    public Task<List<MeterType>> GetAllAsync(string? search = null)
     {
-        var pattern = $"%{search}%";
-        return _db.MeterTypes
-            .Where(m => EF.Functions.ILike(m.Type, pattern) || EF.Functions.ILike(m.FullName, pattern))
-            .OrderBy(m => m.Type)
-            .Take(20)
-            .ToListAsync();
+        IQueryable<MeterType> query = _db.MeterTypes;
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var pattern = $"%{search}%";
+            query = query.Where(m => EF.Functions.ILike(m.Type, pattern));
+        }
+
+        return query.OrderBy(m => m.Type).ToListAsync();
     }
 
     public Task<MeterType?> GetAsync(int id) => _db.MeterTypes.FindAsync(id).AsTask();


### PR DESCRIPTION
## Summary
- align flowmeter labels and enable checkboxes within group boxes
- remove unused test controls
- hide group box content when flowmeter is disabled

## Testing
- `dotnet build Poverka.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ac8b12dba88331999bdb33d6d21599