### PR TITLE
Implement manufacturer autocomplete and rename Type label

### DIFF
--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -274,7 +274,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow1_GosReestr_CB
             // 
             Flow1_GosReestr_CB.AllowDrop = true;
-            Flow1_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow1_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow1_GosReestr_CB.FormattingEnabled = true;
             Flow1_GosReestr_CB.IntegralHeight = false;
             Flow1_GosReestr_CB.Location = new Point(168, 67);
@@ -283,6 +284,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_GosReestr_CB.Size = new Size(155, 23);
             Flow1_GosReestr_CB.TabIndex = 22;
             Flow1_GosReestr_CB.SelectedIndexChanged += GosReestrCB_SelectedIndexChanged;
+            Flow1_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow1_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow1_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // label1
             // 
@@ -420,7 +424,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow2_GosReestr_CB
             // 
             Flow2_GosReestr_CB.AllowDrop = true;
-            Flow2_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow2_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow2_GosReestr_CB.FormattingEnabled = true;
             Flow2_GosReestr_CB.IntegralHeight = false;
             Flow2_GosReestr_CB.Location = new Point(168, 67);
@@ -429,6 +434,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_GosReestr_CB.Size = new Size(155, 23);
             Flow2_GosReestr_CB.TabIndex = 22;
             Flow2_GosReestr_CB.SelectedIndexChanged += Flow2_GosReestr_CB_SelectedIndexChanged;
+            Flow2_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow2_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow2_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // Flow2_Document_CB
             // 
@@ -614,7 +622,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow3_GosReestr_CB
             // 
             Flow3_GosReestr_CB.AllowDrop = true;
-            Flow3_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow3_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow3_GosReestr_CB.FormattingEnabled = true;
             Flow3_GosReestr_CB.IntegralHeight = false;
             Flow3_GosReestr_CB.Location = new Point(168, 67);
@@ -623,6 +632,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_GosReestr_CB.Size = new Size(155, 23);
             Flow3_GosReestr_CB.TabIndex = 22;
             Flow3_GosReestr_CB.SelectedIndexChanged += Flow3_GosReestr_CB_SelectedIndexChanged;
+            Flow3_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow3_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow3_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // Flow3_Document_CB
             // 
@@ -807,7 +819,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow4_GosReestr_CB
             // 
             Flow4_GosReestr_CB.AllowDrop = true;
-            Flow4_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow4_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow4_GosReestr_CB.FormattingEnabled = true;
             Flow4_GosReestr_CB.IntegralHeight = false;
             Flow4_GosReestr_CB.Location = new Point(168, 67);
@@ -816,6 +829,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_GosReestr_CB.Size = new Size(155, 23);
             Flow4_GosReestr_CB.TabIndex = 22;
             Flow4_GosReestr_CB.SelectedIndexChanged += Flow4_GosReestr_CB_SelectedIndexChanged;
+            Flow4_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow4_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow4_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // Flow4_Document_CB
             // 
@@ -876,7 +892,7 @@ namespace PoverkaWinForms.Forms.Verifier
             label29.Name = "label29";
             label29.Size = new Size(117, 15);
             label29.TabIndex = 21;
-            label29.Text = "Наиименование СИ";
+            label29.Text = "Тип";
             // 
             // label30
             // 
@@ -1000,7 +1016,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow5_GosReestr_CB
             // 
             Flow5_GosReestr_CB.AllowDrop = true;
-            Flow5_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow5_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow5_GosReestr_CB.FormattingEnabled = true;
             Flow5_GosReestr_CB.IntegralHeight = false;
             Flow5_GosReestr_CB.Location = new Point(168, 67);
@@ -1009,6 +1026,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_GosReestr_CB.Size = new Size(155, 23);
             Flow5_GosReestr_CB.TabIndex = 22;
             Flow5_GosReestr_CB.SelectedIndexChanged += Flow5_GosReestr_CB_SelectedIndexChanged;
+            Flow5_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow5_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow5_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // Flow5_Document_CB
             // 
@@ -1194,7 +1214,8 @@ namespace PoverkaWinForms.Forms.Verifier
             // Flow6_GosReestr_CB
             // 
             Flow6_GosReestr_CB.AllowDrop = true;
-            Flow6_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDownList;
+            Flow6_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
             Flow6_GosReestr_CB.FormattingEnabled = true;
             Flow6_GosReestr_CB.IntegralHeight = false;
             Flow6_GosReestr_CB.Location = new Point(168, 67);
@@ -1203,6 +1224,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_GosReestr_CB.Size = new Size(155, 23);
             Flow6_GosReestr_CB.TabIndex = 22;
             Flow6_GosReestr_CB.SelectedIndexChanged += Flow6_GosReestr_CB_SelectedIndexChanged;
+            Flow6_GosReestr_CB.Click += ManufacturerCB_Click;
+            Flow6_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow6_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
             // 
             // Flow6_Document_CB
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -1165,7 +1165,6 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer6_GB.TabIndex = 37;
             Rashodomer6_GB.TabStop = false;
             Rashodomer6_GB.Tag = "FirstFlowmeter";
-            Rashodomer6_GB.Enter += groupBox6_Enter;
             // 
             // label41
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -10,6 +10,7 @@ namespace PoverkaWinForms.Forms.Verifier
     public partial class MetersSetupForm : Form
     {
         private readonly MeterTypeService _meterTypeService = null!;
+        private readonly ManufacturerService _manufacturerService = null!;
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
@@ -26,14 +27,16 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
         }
 
-    public MetersSetupForm(MeterTypeService meterTypeService) : this()
-    {
-        _meterTypeService = meterTypeService;
-    }
+        public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService) : this()
+        {
+            _meterTypeService = meterTypeService;
+            _manufacturerService = manufacturerService;
+        }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
         {
             await _meterTypeService.GetAllAsync(string.Empty, 10);
+            await _manufacturerService.GetAllAsync(string.Empty, 10);
         }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -58,6 +61,33 @@ namespace PoverkaWinForms.Forms.Verifier
             combo.DataSource = items;
             combo.DisplayMember = nameof(MeterTypeDto.Type);
             combo.ValueMember = nameof(MeterTypeDto.Id);
+            combo.SelectedIndex = -1;
+            combo.Text = search;
+            combo.SelectionStart = selStart;
+            combo.SelectionLength = 0;
+            combo.EndUpdate();
+            _typedTexts[combo] = search;
+
+            if (dropDown)
+            {
+                combo.DroppedDown = true;
+                Cursor.Current = Cursors.Default;
+                Cursor.Show();
+            }
+
+            _updating = false;
+        }
+
+        private async Task PopulateManufacturersAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
+        {
+            var items = await _manufacturerService.GetAllAsync(search, limit);
+
+            var selStart = combo.SelectionStart;
+            _updating = true;
+            combo.BeginUpdate();
+            combo.DataSource = items;
+            combo.DisplayMember = nameof(ManufacturerDto.Name);
+            combo.ValueMember = nameof(ManufacturerDto.Id);
             combo.SelectedIndex = -1;
             combo.Text = search;
             combo.SelectionStart = selStart;
@@ -169,6 +199,45 @@ namespace PoverkaWinForms.Forms.Verifier
                 await PopulateMeterTypesAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
             }
         }
+        private async void ManufacturerCB_KeyUp(object? sender, KeyEventArgs e)
+        {
+            if (_updating || sender is not ComboBox combo)
+                return;
+
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down ||
+                e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+                return;
+
+            var keyChar = (char)e.KeyValue;
+            if (!char.IsLetter(keyChar) && e.KeyCode != Keys.Back && e.KeyCode != Keys.Delete)
+                return;
+
+            _typedTexts[combo] = combo.Text;
+
+            if (_searchTokens.TryGetValue(combo, out var prev))
+                prev.Cancel();
+
+            var cts = new CancellationTokenSource();
+            _searchTokens[combo] = cts;
+
+            try
+            {
+                await Task.Delay(300, cts.Token);
+                await PopulateManufacturersAsync(combo, combo.Text, limit: 20, dropDown: true);
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+
+        private async void ManufacturerCB_Click(object? sender, EventArgs e)
+        {
+            if (sender is ComboBox combo)
+            {
+                combo.SelectionLength = 0;
+                await PopulateManufacturersAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
+            }
+        }
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
         private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
         private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -185,6 +254,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer1_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow1_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -194,6 +264,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer2_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow2_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -203,6 +274,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer3_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow3_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -212,6 +284,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer6_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow6_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -221,6 +294,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer5_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow5_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -230,6 +304,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer4_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, 10);
+            await PopulateManufacturersAsync(Flow4_GosReestr_CB, string.Empty, 10);
             }
         }
         private void groupBox6_Enter(object sender, EventArgs e)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -3,35 +3,28 @@ using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
-using System.Drawing;
 using PoverkaWinForms.Services;
 
 namespace PoverkaWinForms.Forms.Verifier
 {
     public partial class MetersSetupForm : Form
     {
-        private readonly MeterTypeService _meterTypeService = null!;
-        private readonly ManufacturerService _manufacturerService = null!;
+        private readonly MeterTypeService _meterTypeService;
+        private readonly ManufacturerService _manufacturerService;
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
-        public MetersSetupForm()
-        {
-            InitializeComponent();
-        }
-
-        public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService) : this()
+        public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService)
         {
             _meterTypeService = meterTypeService;
             _manufacturerService = manufacturerService;
+            InitializeComponent();
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
         {
             if (DesignMode)
                 return;
-
-            AddDateFields();
 
             Rashodomer1_CB_CheckedChanged(null, EventArgs.Empty);
             Rashodomer2_CB_CheckedChanged(null, EventArgs.Empty);
@@ -44,68 +37,6 @@ namespace PoverkaWinForms.Forms.Verifier
             await _manufacturerService.GetAllAsync(string.Empty, 10);
         }
 
-        private void AddDateFields()
-        {
-            int offset = AddDateField(Rashodomer1_GB, GosReestr, Flow1_GosReestr_CB, label3, Flow1_Modification_CB,
-                new Control[] { label4, Flow1_ZavodskNomer_TB, label5, Flow1_Diameter_CB, label6, Flow1_WeightImpulse_TB, label7, Flow1_Document_CB });
-            ShiftGroupBoxes(new[] { Rashodomer2_GB, Rashodomer3_GB, Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
-
-            offset = AddDateField(Rashodomer2_GB, label12, Flow2_GosReestr_CB, label16, Flow2_Modification_CB,
-                new Control[] { label17, Flow2_ZavodskNomer_TB, label15, Flow2_Diameter_CB, label13, Flow2_WeightImpulse_TB, label11, Flow2_Document_CB });
-            ShiftGroupBoxes(new[] { Rashodomer3_GB, Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
-
-            offset = AddDateField(Rashodomer3_GB, label19, Flow3_GosReestr_CB, label23, Flow3_Modification_CB,
-                new Control[] { label24, Flow3_ZavodskNomer_TB, label22, Flow3_Diameter_CB, label20, Flow3_WeightImpulse_TB, label18, Flow3_Document_CB });
-            ShiftGroupBoxes(new[] { Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
-
-            offset = AddDateField(Rashodomer4_GB, label27, Flow4_GosReestr_CB, label31, Flow4_Modification_CB,
-                new Control[] { label32, Flow4_ZavodskNomer_TB, label30, Flow4_Diameter_CB, label28, Flow4_WeightImpulse_TB, label26, Flow4_Document_CB });
-            ShiftGroupBoxes(new[] { Rashodomer5_GB, Rashodomer6_GB }, offset);
-
-            offset = AddDateField(Rashodomer5_GB, label35, Flow5_GosReestr_CB, label39, Flow5_Modification_CB,
-                new Control[] { label40, Flow5_ZavodskNomer_TB, label38, Flow5_Diameter_CB, label36, Flow5_WeightImpulse_TB, label34, Flow5_Document_CB });
-            ShiftGroupBoxes(new[] { Rashodomer6_GB }, offset);
-
-            AddDateField(Rashodomer6_GB, label43, Flow6_GosReestr_CB, label47, Flow6_Modification_CB,
-                new Control[] { label48, Flow6_ZavodskNomer_TB, label46, Flow6_Diameter_CB, label44, Flow6_WeightImpulse_TB, label42, Flow6_Document_CB });
-        }
-
-        private int AddDateField(GroupBox groupBox, Label manufacturerLabel, ComboBox manufacturerCombo,
-            Label modificationLabel, ComboBox modificationCombo, Control[] controlsToShift)
-        {
-            var dateLabel = new Label
-            {
-                AutoSize = true,
-                Text = "Дата выпуска",
-                Location = new Point(manufacturerLabel.Left, manufacturerCombo.Bottom + 10)
-            };
-
-            var datePicker = new DateTimePicker
-            {
-                Format = DateTimePickerFormat.Short,
-                Location = new Point(manufacturerCombo.Left, manufacturerCombo.Bottom + 8),
-                Size = manufacturerCombo.Size
-            };
-
-            groupBox.Controls.Add(dateLabel);
-            groupBox.Controls.Add(datePicker);
-
-            int offset = datePicker.Height + 8;
-            modificationLabel.Top += offset;
-            modificationCombo.Top += offset;
-
-            foreach (var ctrl in controlsToShift)
-                ctrl.Top += offset;
-
-            groupBox.Height += offset;
-            return offset;
-        }
-
-        private static void ShiftGroupBoxes(GroupBox[] groups, int offset)
-        {
-            foreach (var gb in groups)
-                gb.Top += offset;
-        }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
 

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Windows.Forms;
-using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 using PoverkaWinForms.Services;
 
 namespace PoverkaWinForms.Forms.Verifier
@@ -14,7 +14,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
-        public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService)
+
+        public MetersSetupForm(
+            MeterTypeService meterTypeService,
+            ManufacturerService manufacturerService
+        )
         {
             _meterTypeService = meterTypeService;
             _manufacturerService = manufacturerService;
@@ -37,7 +41,6 @@ namespace PoverkaWinForms.Forms.Verifier
             await _manufacturerService.GetAllAsync(string.Empty, 10);
         }
 
-
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
 
         private void Flow2_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
@@ -50,7 +53,12 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void Flow6_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
 
-        private async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
+        private async Task PopulateMeterTypesAsync(
+            ComboBox combo,
+            string search,
+            int? limit = null,
+            bool dropDown = false
+        )
         {
             var items = await _meterTypeService.GetAllAsync(search, limit);
 
@@ -77,7 +85,12 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        private async Task PopulateManufacturersAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
+        private async Task PopulateManufacturersAsync(
+            ComboBox combo,
+            string search,
+            int? limit = null,
+            bool dropDown = false
+        )
         {
             var items = await _manufacturerService.GetAllAsync(search, limit);
 
@@ -144,18 +157,22 @@ namespace PoverkaWinForms.Forms.Verifier
                 if (count == 0)
                     return;
                 int newIndex = combo.SelectedIndex + direction;
-                if (newIndex < 0) newIndex = count - 1;
-                if (newIndex >= count) newIndex = 0;
+                if (newIndex < 0)
+                    newIndex = count - 1;
+                if (newIndex >= count)
+                    newIndex = 0;
                 combo.SelectedIndex = newIndex;
 
-                BeginInvoke(new Action(() =>
-                {
-                    _updating = true;
-                    combo.Text = text;
-                    combo.SelectionStart = text.Length;
-                    combo.SelectionLength = 0;
-                    _updating = false;
-                }));
+                BeginInvoke(
+                    new Action(() =>
+                    {
+                        _updating = true;
+                        combo.Text = text;
+                        combo.SelectionStart = text.Length;
+                        combo.SelectionLength = 0;
+                        _updating = false;
+                    })
+                );
             }
         }
 
@@ -164,8 +181,13 @@ namespace PoverkaWinForms.Forms.Verifier
             if (_updating || sender is not ComboBox combo)
                 return;
 
-            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down ||
-                e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            if (
+                e.KeyCode == Keys.Enter
+                || e.KeyCode == Keys.Up
+                || e.KeyCode == Keys.Down
+                || e.KeyCode == Keys.Left
+                || e.KeyCode == Keys.Right
+            )
                 return;
 
             var keyChar = (char)e.KeyValue;
@@ -185,9 +207,7 @@ namespace PoverkaWinForms.Forms.Verifier
                 await Task.Delay(300, cts.Token);
                 await PopulateMeterTypesAsync(combo, combo.Text, limit: 20, dropDown: true);
             }
-            catch (TaskCanceledException)
-            {
-            }
+            catch (TaskCanceledException) { }
         }
 
         private async void MeterTypeCB_Click(object? sender, EventArgs e)
@@ -195,16 +215,27 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo)
             {
                 combo.SelectionLength = 0;
-                await PopulateMeterTypesAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
+                await PopulateMeterTypesAsync(
+                    combo,
+                    combo.Text,
+                    combo.Text.Length > 0 ? 20 : 10,
+                    dropDown: true
+                );
             }
         }
+
         private async void ManufacturerCB_KeyUp(object? sender, KeyEventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
                 return;
 
-            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down ||
-                e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            if (
+                e.KeyCode == Keys.Enter
+                || e.KeyCode == Keys.Up
+                || e.KeyCode == Keys.Down
+                || e.KeyCode == Keys.Left
+                || e.KeyCode == Keys.Right
+            )
                 return;
 
             var keyChar = (char)e.KeyValue;
@@ -224,9 +255,7 @@ namespace PoverkaWinForms.Forms.Verifier
                 await Task.Delay(300, cts.Token);
                 await PopulateManufacturersAsync(combo, combo.Text, limit: 20, dropDown: true);
             }
-            catch (TaskCanceledException)
-            {
-            }
+            catch (TaskCanceledException) { }
         }
 
         private async void ManufacturerCB_Click(object? sender, EventArgs e)
@@ -234,17 +263,31 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo)
             {
                 combo.SelectionLength = 0;
-                await PopulateManufacturersAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
+                await PopulateManufacturersAsync(
+                    combo,
+                    combo.Text,
+                    combo.Text.Length > 0 ? 20 : 10,
+                    dropDown: true
+                );
             }
         }
+
         private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void Flow4_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void Flow5_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+
         private void label14_Click(object sender, EventArgs e) { }
+
         private void Next_B_Click(object sender, EventArgs e) { }
+
         private void button1_Click(object sender, EventArgs e) { }
 
         private async void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
@@ -253,7 +296,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer1_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow1_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow1_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -263,7 +306,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer2_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow2_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow2_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -273,7 +316,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer3_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow3_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow3_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -283,7 +326,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer6_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow6_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow6_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -293,7 +336,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer5_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow5_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow5_GosReestr_CB, string.Empty, 10);
             }
         }
 
@@ -303,12 +346,8 @@ namespace PoverkaWinForms.Forms.Verifier
             if (Rashodomer4_CB.Checked)
             {
                 await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, 10);
-            await PopulateManufacturersAsync(Flow4_GosReestr_CB, string.Empty, 10);
+                await PopulateManufacturersAsync(Flow4_GosReestr_CB, string.Empty, 10);
             }
-        }
-        private void groupBox6_Enter(object sender, EventArgs e)
-        {
-            // TODO: добавить логику обработки при необходимости
         }
 
         private static void ToggleGroupControls(GroupBox groupBox, CheckBox checkBox, Label caption)
@@ -323,6 +362,5 @@ namespace PoverkaWinForms.Forms.Verifier
                 }
             }
         }
-
     }
 }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -15,19 +15,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
-        private readonly List<DateTimePicker> _datePickers = new();
-
         public MetersSetupForm()
         {
             InitializeComponent();
-
-            Rashodomer1_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer2_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer3_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer4_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer5_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
-            AddDateFields();
         }
 
         public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService) : this()
@@ -38,6 +28,18 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
         {
+            if (DesignMode)
+                return;
+
+            AddDateFields();
+
+            Rashodomer1_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer2_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer3_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer4_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer5_CB_CheckedChanged(null, EventArgs.Empty);
+            Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
+
             await _meterTypeService.GetAllAsync(string.Empty, 10);
             await _manufacturerService.GetAllAsync(string.Empty, 10);
         }
@@ -87,7 +89,6 @@ namespace PoverkaWinForms.Forms.Verifier
 
             groupBox.Controls.Add(dateLabel);
             groupBox.Controls.Add(datePicker);
-            _datePickers.Add(datePicker);
 
             int offset = datePicker.Height + 8;
             modificationLabel.Top += offset;

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
+using System.Drawing;
 using PoverkaWinForms.Services;
 
 namespace PoverkaWinForms.Forms.Verifier
@@ -14,6 +15,7 @@ namespace PoverkaWinForms.Forms.Verifier
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
+        private readonly List<DateTimePicker> _datePickers = new();
 
         public MetersSetupForm()
         {
@@ -25,6 +27,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer4_CB_CheckedChanged(null, EventArgs.Empty);
             Rashodomer5_CB_CheckedChanged(null, EventArgs.Empty);
             Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
+            AddDateFields();
         }
 
         public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService) : this()
@@ -37,6 +40,70 @@ namespace PoverkaWinForms.Forms.Verifier
         {
             await _meterTypeService.GetAllAsync(string.Empty, 10);
             await _manufacturerService.GetAllAsync(string.Empty, 10);
+        }
+
+        private void AddDateFields()
+        {
+            int offset = AddDateField(Rashodomer1_GB, GosReestr, Flow1_GosReestr_CB, label3, Flow1_Modification_CB,
+                new Control[] { label4, Flow1_ZavodskNomer_TB, label5, Flow1_Diameter_CB, label6, Flow1_WeightImpulse_TB, label7, Flow1_Document_CB });
+            ShiftGroupBoxes(new[] { Rashodomer2_GB, Rashodomer3_GB, Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
+
+            offset = AddDateField(Rashodomer2_GB, label12, Flow2_GosReestr_CB, label16, Flow2_Modification_CB,
+                new Control[] { label17, Flow2_ZavodskNomer_TB, label15, Flow2_Diameter_CB, label13, Flow2_WeightImpulse_TB, label11, Flow2_Document_CB });
+            ShiftGroupBoxes(new[] { Rashodomer3_GB, Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
+
+            offset = AddDateField(Rashodomer3_GB, label19, Flow3_GosReestr_CB, label23, Flow3_Modification_CB,
+                new Control[] { label24, Flow3_ZavodskNomer_TB, label22, Flow3_Diameter_CB, label20, Flow3_WeightImpulse_TB, label18, Flow3_Document_CB });
+            ShiftGroupBoxes(new[] { Rashodomer4_GB, Rashodomer5_GB, Rashodomer6_GB }, offset);
+
+            offset = AddDateField(Rashodomer4_GB, label27, Flow4_GosReestr_CB, label31, Flow4_Modification_CB,
+                new Control[] { label32, Flow4_ZavodskNomer_TB, label30, Flow4_Diameter_CB, label28, Flow4_WeightImpulse_TB, label26, Flow4_Document_CB });
+            ShiftGroupBoxes(new[] { Rashodomer5_GB, Rashodomer6_GB }, offset);
+
+            offset = AddDateField(Rashodomer5_GB, label35, Flow5_GosReestr_CB, label39, Flow5_Modification_CB,
+                new Control[] { label40, Flow5_ZavodskNomer_TB, label38, Flow5_Diameter_CB, label36, Flow5_WeightImpulse_TB, label34, Flow5_Document_CB });
+            ShiftGroupBoxes(new[] { Rashodomer6_GB }, offset);
+
+            AddDateField(Rashodomer6_GB, label43, Flow6_GosReestr_CB, label47, Flow6_Modification_CB,
+                new Control[] { label48, Flow6_ZavodskNomer_TB, label46, Flow6_Diameter_CB, label44, Flow6_WeightImpulse_TB, label42, Flow6_Document_CB });
+        }
+
+        private int AddDateField(GroupBox groupBox, Label manufacturerLabel, ComboBox manufacturerCombo,
+            Label modificationLabel, ComboBox modificationCombo, Control[] controlsToShift)
+        {
+            var dateLabel = new Label
+            {
+                AutoSize = true,
+                Text = "Дата выпуска",
+                Location = new Point(manufacturerLabel.Left, manufacturerCombo.Bottom + 10)
+            };
+
+            var datePicker = new DateTimePicker
+            {
+                Format = DateTimePickerFormat.Short,
+                Location = new Point(manufacturerCombo.Left, manufacturerCombo.Bottom + 8),
+                Size = manufacturerCombo.Size
+            };
+
+            groupBox.Controls.Add(dateLabel);
+            groupBox.Controls.Add(datePicker);
+            _datePickers.Add(datePicker);
+
+            int offset = datePicker.Height + 8;
+            modificationLabel.Top += offset;
+            modificationCombo.Top += offset;
+
+            foreach (var ctrl in controlsToShift)
+                ctrl.Top += offset;
+
+            groupBox.Height += offset;
+            return offset;
+        }
+
+        private static void ShiftGroupBoxes(GroupBox[] groups, int offset)
+        {
+            foreach (var gb in groups)
+                gb.Top += offset;
         }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -1,11 +1,11 @@
 using System;
+using System.Windows.Forms;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System.Windows.Forms;
 using PoverkaWinForms.Forms.Admin;
 using PoverkaWinForms.Forms.Verifier;
-using PoverkaWinForms.Services;
 using PoverkaWinForms.Http;
+using PoverkaWinForms.Services;
 
 namespace PoverkaWinForms
 {
@@ -26,11 +26,9 @@ namespace PoverkaWinForms
             services.AddIdentityServerSettings(configuration);
             services.AddSingleton<IConfiguration>(configuration);
             services.AddTransient<HttpErrorHandler>();
-            services.AddHttpClient("AuthClient")
-                .AddHttpMessageHandler<HttpErrorHandler>();
+            services.AddHttpClient("AuthClient").AddHttpMessageHandler<HttpErrorHandler>();
             services.AddSingleton<TokenService>();
-            services.AddHttpClient("ApiClient")
-                .AddHttpMessageHandler<HttpErrorHandler>();
+            services.AddHttpClient("ApiClient").AddHttpMessageHandler<HttpErrorHandler>();
             services.AddTransient<UserService>();
             services.AddTransient<MeterImportService>();
             services.AddTransient<MeterTypeService>();

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -34,6 +34,7 @@ namespace PoverkaWinForms
             services.AddTransient<UserService>();
             services.AddTransient<MeterImportService>();
             services.AddTransient<MeterTypeService>();
+            services.AddTransient<ManufacturerService>();
 
             services.AddScoped<MetersSetupForm>();
             services.AddScoped<ConfigurationForm>();

--- a/Client/Services/ManufacturerService.cs
+++ b/Client/Services/ManufacturerService.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using PoverkaWinForms.Settings;
+
+namespace PoverkaWinForms.Services;
+
+public class ManufacturerService
+{
+    private readonly HttpClient _http;
+    private readonly TokenService _tokens;
+    private List<ManufacturerDto> _defaultManufacturers = new();
+
+    public ManufacturerService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
+    {
+        _http = factory.CreateClient("ApiClient");
+        _http.BaseAddress = new Uri(settings.Authority);
+        _tokens = tokens;
+    }
+
+    public async Task<List<ManufacturerDto>> GetAllAsync(string search, int? take = null)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            if (_defaultManufacturers.Count > 0)
+                return _defaultManufacturers;
+        }
+
+        var token = await _tokens.GetAccessTokenAsync();
+        if (token is null) return new();
+
+        var url = "/api/manufacturers";
+        if (!string.IsNullOrWhiteSpace(search) || take.HasValue)
+        {
+            var query = new List<string>();
+            if (!string.IsNullOrWhiteSpace(search))
+                query.Add($"search={Uri.EscapeDataString(search)}");
+            if (take.HasValue)
+                query.Add($"take={take.Value}");
+            url += "?" + string.Join("&", query);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        if (!response.IsSuccessStatusCode) return new();
+
+        var items = await response.Content.ReadFromJsonAsync<List<ManufacturerDto>>();
+        items ??= new();
+
+        if (string.IsNullOrWhiteSpace(search))
+            _defaultManufacturers = items;
+
+        return items;
+    }
+}
+
+public record ManufacturerDto(int Id, string Name);

--- a/Client/Services/ManufacturerService.cs
+++ b/Client/Services/ManufacturerService.cs
@@ -14,7 +14,11 @@ public class ManufacturerService
     private readonly TokenService _tokens;
     private List<ManufacturerDto> _defaultManufacturers = new();
 
-    public ManufacturerService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
+    public ManufacturerService(
+        IHttpClientFactory factory,
+        TokenService tokens,
+        IdentityServerSettings settings
+    )
     {
         _http = factory.CreateClient("ApiClient");
         _http.BaseAddress = new Uri(settings.Authority);
@@ -30,7 +34,8 @@ public class ManufacturerService
         }
 
         var token = await _tokens.GetAccessTokenAsync();
-        if (token is null) return new();
+        if (token is null)
+            return new();
 
         var url = "/api/manufacturers";
         if (!string.IsNullOrWhiteSpace(search) || take.HasValue)
@@ -46,7 +51,8 @@ public class ManufacturerService
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var response = await _http.SendAsync(request);
-        if (!response.IsSuccessStatusCode) return new();
+        if (!response.IsSuccessStatusCode)
+            return new();
 
         var items = await response.Content.ReadFromJsonAsync<List<ManufacturerDto>>();
         items ??= new();


### PR DESCRIPTION
## Summary
- Rename meter name label to "Тип"
- Add manufacturer autocomplete using new ManufacturerService
- Register ManufacturerService and load manufacturer data in setup form

## Testing
- `dotnet build Poverka.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b32dd0bd2c8331b9fec75756b9bfe1