### PR TITLE
Load modifications based on type, manufacturer and date

### DIFF
--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -311,6 +311,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow1_ManufactureDate_DTP.TabIndex = 24;
             Flow1_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow1_ManufactureDate_DTP.ValueChanged += Flow1_ManufactureDate_DTP_ValueChanged;
             //
             // Flow1_ManufactureDate_L
             //
@@ -486,6 +487,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow2_ManufactureDate_DTP.TabIndex = 24;
             Flow2_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow2_ManufactureDate_DTP.ValueChanged += Flow2_ManufactureDate_DTP_ValueChanged;
             //
             // Flow2_ManufactureDate_L
             //
@@ -708,6 +710,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow3_ManufactureDate_DTP.TabIndex = 24;
             Flow3_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow3_ManufactureDate_DTP.ValueChanged += Flow3_ManufactureDate_DTP_ValueChanged;
             //
             // Flow3_ManufactureDate_L
             //
@@ -929,6 +932,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow4_ManufactureDate_DTP.TabIndex = 24;
             Flow4_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow4_ManufactureDate_DTP.ValueChanged += Flow4_ManufactureDate_DTP_ValueChanged;
             //
             // Flow4_ManufactureDate_L
             //
@@ -1150,6 +1154,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow5_ManufactureDate_DTP.TabIndex = 24;
             Flow5_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow5_ManufactureDate_DTP.ValueChanged += Flow5_ManufactureDate_DTP_ValueChanged;
             //
             // Flow5_ManufactureDate_L
             //
@@ -1371,6 +1376,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow6_ManufactureDate_DTP.TabIndex = 24;
             Flow6_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow6_ManufactureDate_DTP.ValueChanged += Flow6_ManufactureDate_DTP_ValueChanged;
             //
             // Flow6_ManufactureDate_L
             //

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -249,6 +249,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Modification_CB.Name = "Flow1_Modification_CB";
             Flow1_Modification_CB.Size = new Size(155, 23);
             Flow1_Modification_CB.TabIndex = 24;
+            Flow1_Modification_CB.Click += Flow1_Modification_CB_Click;
             //
             // label2
             //
@@ -577,7 +578,8 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Modification_CB.Name = "Flow2_Modification_CB";
             Flow2_Modification_CB.Size = new Size(155, 23);
             Flow2_Modification_CB.TabIndex = 24;
-            // 
+            Flow2_Modification_CB.Click += Flow2_Modification_CB_Click;
+            //
             // label16
             // 
             label16.AutoSize = true;
@@ -797,7 +799,8 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Modification_CB.Name = "Flow3_Modification_CB";
             Flow3_Modification_CB.Size = new Size(155, 23);
             Flow3_Modification_CB.TabIndex = 24;
-            // 
+            Flow3_Modification_CB.Click += Flow3_Modification_CB_Click;
+            //
             // label23
             // 
             label23.AutoSize = true;
@@ -1017,7 +1020,8 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Modification_CB.Name = "Flow4_Modification_CB";
             Flow4_Modification_CB.Size = new Size(155, 23);
             Flow4_Modification_CB.TabIndex = 24;
-            // 
+            Flow4_Modification_CB.Click += Flow4_Modification_CB_Click;
+            //
             // label31
             // 
             label31.AutoSize = true;
@@ -1237,7 +1241,8 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Modification_CB.Name = "Flow5_Modification_CB";
             Flow5_Modification_CB.Size = new Size(155, 23);
             Flow5_Modification_CB.TabIndex = 24;
-            // 
+            Flow5_Modification_CB.Click += Flow5_Modification_CB_Click;
+            //
             // label39
             // 
             label39.AutoSize = true;
@@ -1457,6 +1462,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Modification_CB.Name = "Flow6_Modification_CB";
             Flow6_Modification_CB.Size = new Size(155, 23);
             Flow6_Modification_CB.TabIndex = 24;
+            Flow6_Modification_CB.Click += Flow6_Modification_CB_Click;
             // 
             // label47
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -331,6 +331,24 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow6_Modification_CB);
 
+        private void Flow1_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow1_Modification_CB);
+
+        private void Flow2_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow2_Modification_CB);
+
+        private void Flow3_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow3_Modification_CB);
+
+        private void Flow4_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow4_Modification_CB);
+
+        private void Flow5_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow5_Modification_CB);
+
+        private void Flow6_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow6_Modification_CB);
+
         private void label14_Click(object sender, EventArgs e) { }
 
         private void Next_B_Click(object sender, EventArgs e) { }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -11,17 +11,20 @@ namespace PoverkaWinForms.Forms.Verifier
     {
         private readonly MeterTypeService _meterTypeService;
         private readonly ManufacturerService _manufacturerService;
+        private readonly ModificationService _modificationService;
         private bool _updating;
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
 
         public MetersSetupForm(
             MeterTypeService meterTypeService,
-            ManufacturerService manufacturerService
+            ManufacturerService manufacturerService,
+            ModificationService modificationService
         )
         {
             _meterTypeService = meterTypeService;
             _manufacturerService = manufacturerService;
+            _modificationService = modificationService;
             InitializeComponent();
         }
 
@@ -114,6 +117,31 @@ namespace PoverkaWinForms.Forms.Verifier
                 Cursor.Show();
             }
 
+            _updating = false;
+        }
+
+        private async Task PopulateModificationsAsync(
+            ComboBox modificationCombo,
+            ComboBox meterTypeCombo,
+            ComboBox manufacturerCombo,
+            DateTimePicker datePicker
+        )
+        {
+            if (meterTypeCombo.SelectedValue is not int meterTypeId)
+                return;
+            if (manufacturerCombo.SelectedValue is not int manufacturerId)
+                return;
+
+            var manufactureDate = DateOnly.FromDateTime(datePicker.Value);
+            var items = await _modificationService.GetAllAsync(meterTypeId, manufacturerId, manufactureDate);
+
+            _updating = true;
+            modificationCombo.BeginUpdate();
+            modificationCombo.DataSource = items;
+            modificationCombo.DisplayMember = nameof(ModificationDto.Name);
+            modificationCombo.ValueMember = nameof(ModificationDto.Id);
+            modificationCombo.SelectedIndex = -1;
+            modificationCombo.EndUpdate();
             _updating = false;
         }
 
@@ -289,6 +317,54 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Next_B_Click(object sender, EventArgs e) { }
 
         private void button1_Click(object sender, EventArgs e) { }
+
+        private async void Flow1_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow1_Modification_CB,
+                Flow1_Name_SI_CB,
+                Flow1_GosReestr_CB,
+                Flow1_ManufactureDate_DTP
+            );
+
+        private async void Flow2_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow2_Modification_CB,
+                Flow2_Name_SI_CB,
+                Flow2_GosReestr_CB,
+                Flow2_ManufactureDate_DTP
+            );
+
+        private async void Flow3_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow3_Modification_CB,
+                Flow3_Name_SI_CB,
+                Flow3_GosReestr_CB,
+                Flow3_ManufactureDate_DTP
+            );
+
+        private async void Flow4_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow4_Modification_CB,
+                Flow4_Name_SI_CB,
+                Flow4_GosReestr_CB,
+                Flow4_ManufactureDate_DTP
+            );
+
+        private async void Flow5_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow5_Modification_CB,
+                Flow5_Name_SI_CB,
+                Flow5_GosReestr_CB,
+                Flow5_ManufactureDate_DTP
+            );
+
+        private async void Flow6_Modification_CB_Click(object? sender, EventArgs e) =>
+            await PopulateModificationsAsync(
+                Flow6_Modification_CB,
+                Flow6_Name_SI_CB,
+                Flow6_GosReestr_CB,
+                Flow6_ManufactureDate_DTP
+            );
 
         private async void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
         {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -44,17 +44,30 @@ namespace PoverkaWinForms.Forms.Verifier
             await _manufacturerService.GetAllAsync(string.Empty, 10);
         }
 
-        private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private static void ResetModifications(ComboBox modificationCombo)
+        {
+            modificationCombo.DataSource = null;
+            modificationCombo.Items.Clear();
+            modificationCombo.SelectedIndex = -1;
+        }
 
-        private void Flow2_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow1_Modification_CB);
 
-        private void Flow3_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow2_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow2_Modification_CB);
 
-        private void Flow4_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow3_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow3_Modification_CB);
 
-        private void Flow5_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow4_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow4_Modification_CB);
 
-        private void Flow6_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow5_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow5_Modification_CB);
+
+        private void Flow6_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow6_Modification_CB);
 
         private async Task PopulateMeterTypesAsync(
             ComboBox combo,
@@ -300,17 +313,23 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow1_Modification_CB);
 
-        private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow2_Modification_CB);
 
-        private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow3_Modification_CB);
 
-        private void Flow4_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow4_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow4_Modification_CB);
 
-        private void Flow5_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow5_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow5_Modification_CB);
 
-        private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) { }
+        private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+            ResetModifications(Flow6_Modification_CB);
 
         private void label14_Click(object sender, EventArgs e) { }
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -33,6 +33,7 @@ namespace PoverkaWinForms
             services.AddTransient<MeterImportService>();
             services.AddTransient<MeterTypeService>();
             services.AddTransient<ManufacturerService>();
+            services.AddTransient<ModificationService>();
 
             services.AddScoped<MetersSetupForm>();
             services.AddScoped<ConfigurationForm>();

--- a/Client/Services/ModificationService.cs
+++ b/Client/Services/ModificationService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using PoverkaWinForms.Settings;
+
+namespace PoverkaWinForms.Services;
+
+public class ModificationService
+{
+    private readonly HttpClient _http;
+    private readonly TokenService _tokens;
+
+    public ModificationService(IHttpClientFactory factory, TokenService tokens, IdentityServerSettings settings)
+    {
+        _http = factory.CreateClient("ApiClient");
+        _http.BaseAddress = new Uri(settings.Authority);
+        _tokens = tokens;
+    }
+
+    public async Task<List<ModificationDto>> GetAllAsync(int meterTypeId, int manufacturerId, DateOnly manufactureDate)
+    {
+        var token = await _tokens.GetAccessTokenAsync();
+        if (token is null)
+            return new();
+
+        var url = $"/api/modifications?meterTypeId={meterTypeId}&manufacturerId={manufacturerId}&manufactureDate={manufactureDate:yyyy-MM-dd}";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await _http.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+            return new();
+
+        var items = await response.Content.ReadFromJsonAsync<List<ModificationDto>>();
+        return items ?? new();
+    }
+}
+
+public record ModificationDto(int Id, int RegistrationId, string Name);

--- a/Server/Endpoints/Modifications/ModificationEndpoints.cs
+++ b/Server/Endpoints/Modifications/ModificationEndpoints.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using PoverkaServer.Endpoints.Modifications.Requests;
 using PoverkaServer.Endpoints.Modifications.Responses;
+using PoverkaServer.Domain;
 using PoverkaServer.Services;
 using PoverkaServer.Validation;
 
@@ -24,9 +25,26 @@ public static class ModificationEndpoints
         return app;
     }
 
-    private static async Task<Ok<IEnumerable<ModificationResponse>>> GetModifications(ModificationService service)
+    private static async Task<Ok<IEnumerable<ModificationResponse>>> GetModifications(
+        int? meterTypeId,
+        int? manufacturerId,
+        DateOnly? manufactureDate,
+        ModificationService service)
     {
-        var items = await service.GetAllAsync();
+        IEnumerable<Modification> items;
+        if (meterTypeId.HasValue && manufacturerId.HasValue && manufactureDate.HasValue)
+        {
+            items = await service.GetFilteredAsync(
+                meterTypeId.Value,
+                manufacturerId.Value,
+                manufactureDate.Value
+            );
+        }
+        else
+        {
+            items = await service.GetAllAsync();
+        }
+
         return TypedResults.Ok(items.Select(m => new ModificationResponse(m)));
     }
 


### PR DESCRIPTION
## Summary
- add client-side modification service and click handlers to load matching modifications
- extend API and service to filter modifications by meter type, manufacturer and manufacture date

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b34ad345848331a52c221d24a928d1