### PR TITLE
Clear combo values on dropdown and restore if unchanged

### DIFF
--- a/Client/Forms/Verifier/FlowMeterSection.cs
+++ b/Client/Forms/Verifier/FlowMeterSection.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace PoverkaWinForms.Forms.Verifier;
+
+internal sealed class FlowMeterSection
+{
+    public FlowMeterSection(CheckBox checkBox, GroupBox groupBox, Label caption, ComboBox meterType, ComboBox manufacturer, ComboBox modification, DateTimePicker manufactureDate, TextBox registrationNumber)
+    {
+        CheckBox = checkBox;
+        GroupBox = groupBox;
+        Caption = caption;
+        MeterType = meterType;
+        Manufacturer = manufacturer;
+        Modification = modification;
+        ManufactureDate = manufactureDate;
+        RegistrationNumber = registrationNumber;
+    }
+
+    public CheckBox CheckBox { get; }
+    public GroupBox GroupBox { get; }
+    public Label Caption { get; }
+    public ComboBox MeterType { get; }
+    public ComboBox Manufacturer { get; }
+    public ComboBox Modification { get; }
+    public DateTimePicker ManufactureDate { get; }
+    public TextBox RegistrationNumber { get; }
+
+    public void ToggleControls()
+    {
+        bool visible = CheckBox.Checked;
+        foreach (Control control in GroupBox.Controls)
+        {
+            if (control != Caption && control != CheckBox)
+                control.Visible = visible;
+        }
+    }
+
+    public async Task OnCheckedChangedAsync(MetersSetupForm form)
+    {
+        ToggleControls();
+
+        if (!CheckBox.Checked)
+            return;
+
+        await form.PopulateMeterTypesAsync(MeterType, string.Empty, 10);
+        await form.PopulateManufacturersAsync(Manufacturer, string.Empty, 10);
+    }
+}

--- a/Client/Forms/Verifier/FlowMeterSection.cs
+++ b/Client/Forms/Verifier/FlowMeterSection.cs
@@ -15,6 +15,13 @@ internal sealed class FlowMeterSection
         Modification = modification;
         ManufactureDate = manufactureDate;
         RegistrationNumber = registrationNumber;
+
+        checkBox.Tag = this;
+        meterType.Tag = this;
+        manufacturer.Tag = this;
+        modification.Tag = this;
+        manufactureDate.Tag = this;
+        registrationNumber.Tag = this;
     }
 
     public CheckBox CheckBox { get; }

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -31,103 +31,103 @@ namespace PoverkaWinForms.Forms.Verifier
             backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
             Flow1_ZavodskNomer_TB = new TextBox();
             Flow1_RegistrationNumber_TB = new TextBox();
-            Flow1_RegistrationNumber_L = new Label();
-            label4 = new Label();
-            label3 = new Label();
+            Flow1_RegistrationNumber_Label = new Label();
+            Flow1_ZavodskNomer_Label = new Label();
+            Flow1_Modification_Label = new Label();
             Flow1_Modification_CB = new ComboBox();
-            label2 = new Label();
+            Flow1_Type_Label = new Label();
             Flow1_Type_CB = new ComboBox();
-            Flow1_Manufacturer_L = new Label();
+            Flow1_Manufacturer_Label = new Label();
             Flow1_Manufacturer_CB = new ComboBox();
             Flow1_ManufactureDate_DTP = new DateTimePicker();
-            Flow1_ManufactureDate_L = new Label();
+            Flow1_ManufactureDate_Label = new Label();
             label1 = new Label();
-            Rashodomer1_GB = new GroupBox();
-            label8 = new Label();
-            Rashodomer1_CB = new CheckBox();
-            Rashodomer2_GB = new GroupBox();
-            label10 = new Label();
-            Rashodomer2_CB = new CheckBox();
+            Flow1_GB = new GroupBox();
+            Flow1_Title_Label = new Label();
+            Flow1_CB = new CheckBox();
+            Flow2_GB = new GroupBox();
+            Flow2_Title_Label = new Label();
+            Flow2_CB = new CheckBox();
             Flow2_Manufacturer_CB = new ComboBox();
             Flow2_ManufactureDate_DTP = new DateTimePicker();
-            Flow2_ManufactureDate_L = new Label();
-            label12 = new Label();
+            Flow2_ManufactureDate_Label = new Label();
+            Flow2_Manufacturer_Label = new Label();
             Flow2_Type_CB = new ComboBox();
-            label14 = new Label();
+            Flow2_Type_Label = new Label();
             Flow2_Modification_CB = new ComboBox();
-            label16 = new Label();
+            Flow2_Modification_Label = new Label();
             Flow2_ZavodskNomer_TB = new TextBox();
             Flow2_RegistrationNumber_TB = new TextBox();
-            Flow2_RegistrationNumber_L = new Label();
-            label17 = new Label();
-            Rashodomer3_GB = new GroupBox();
-            label9 = new Label();
-            Rashodomer3_CB = new CheckBox();
+            Flow2_RegistrationNumber_Label = new Label();
+            Flow2_ZavodskNomer_Label = new Label();
+            Flow3_GB = new GroupBox();
+            Flow3_Title_Label = new Label();
+            Flow3_CB = new CheckBox();
             Flow3_Manufacturer_CB = new ComboBox();
             Flow3_ManufactureDate_DTP = new DateTimePicker();
-            Flow3_ManufactureDate_L = new Label();
-            label19 = new Label();
+            Flow3_ManufactureDate_Label = new Label();
+            Flow3_Manufacturer_Label = new Label();
             Flow3_Type_CB = new ComboBox();
-            label21 = new Label();
+            Flow3_Type_Label = new Label();
             Flow3_Modification_CB = new ComboBox();
-            label23 = new Label();
+            Flow3_Modification_Label = new Label();
             Flow3_ZavodskNomer_TB = new TextBox();
             Flow3_RegistrationNumber_TB = new TextBox();
-            Flow3_RegistrationNumber_L = new Label();
-            label24 = new Label();
-            Rashodomer4_GB = new GroupBox();
-            label25 = new Label();
-            Rashodomer4_CB = new CheckBox();
+            Flow3_RegistrationNumber_Label = new Label();
+            Flow3_ZavodskNomer_Label = new Label();
+            Flow4_GB = new GroupBox();
+            Flow4_Title_Label = new Label();
+            Flow4_CB = new CheckBox();
             Flow4_Manufacturer_CB = new ComboBox();
             Flow4_ManufactureDate_DTP = new DateTimePicker();
-            Flow4_ManufactureDate_L = new Label();
-            label27 = new Label();
+            Flow4_ManufactureDate_Label = new Label();
+            Flow4_Manufacturer_Label = new Label();
             Flow4_Type_CB = new ComboBox();
-            label29 = new Label();
+            Flow4_Type_Label = new Label();
             Flow4_Modification_CB = new ComboBox();
-            label31 = new Label();
+            Flow4_Modification_Label = new Label();
             Flow4_ZavodskNomer_TB = new TextBox();
             Flow4_RegistrationNumber_TB = new TextBox();
-            Flow4_RegistrationNumber_L = new Label();
-            label32 = new Label();
-            Rashodomer5_GB = new GroupBox();
-            label33 = new Label();
-            Rashodomer5_CB = new CheckBox();
+            Flow4_RegistrationNumber_Label = new Label();
+            Flow4_ZavodskNomer_Label = new Label();
+            Flow5_GB = new GroupBox();
+            Flow5_Title_Label = new Label();
+            Flow5_CB = new CheckBox();
             Flow5_Manufacturer_CB = new ComboBox();
             Flow5_ManufactureDate_DTP = new DateTimePicker();
-            Flow5_ManufactureDate_L = new Label();
-            label35 = new Label();
+            Flow5_ManufactureDate_Label = new Label();
+            Flow5_Manufacturer_Label = new Label();
             Flow5_Type_CB = new ComboBox();
-            label37 = new Label();
+            Flow5_Type_Label = new Label();
             Flow5_Modification_CB = new ComboBox();
-            label39 = new Label();
+            Flow5_Modification_Label = new Label();
             Flow5_ZavodskNomer_TB = new TextBox();
             Flow5_RegistrationNumber_TB = new TextBox();
-            Flow5_RegistrationNumber_L = new Label();
-            label40 = new Label();
-            Rashodomer6_GB = new GroupBox();
-            label41 = new Label();
-            Rashodomer6_CB = new CheckBox();
+            Flow5_RegistrationNumber_Label = new Label();
+            Flow5_ZavodskNomer_Label = new Label();
+            Flow6_GB = new GroupBox();
+            Flow6_Title_Label = new Label();
+            Flow6_CB = new CheckBox();
             Flow6_Manufacturer_CB = new ComboBox();
             Flow6_ManufactureDate_DTP = new DateTimePicker();
-            Flow6_ManufactureDate_L = new Label();
-            label43 = new Label();
+            Flow6_ManufactureDate_Label = new Label();
+            Flow6_Manufacturer_Label = new Label();
             Flow6_Type_CB = new ComboBox();
-            label45 = new Label();
+            Flow6_Type_Label = new Label();
             Flow6_Modification_CB = new ComboBox();
-            label47 = new Label();
+            Flow6_Modification_Label = new Label();
             Flow6_ZavodskNomer_TB = new TextBox();
             Flow6_RegistrationNumber_TB = new TextBox();
-            Flow6_RegistrationNumber_L = new Label();
-            label48 = new Label();
+            Flow6_RegistrationNumber_Label = new Label();
+            Flow6_ZavodskNomer_Label = new Label();
             Next_B = new Button();
             button1 = new Button();
-            Rashodomer1_GB.SuspendLayout();
-            Rashodomer2_GB.SuspendLayout();
-            Rashodomer3_GB.SuspendLayout();
-            Rashodomer4_GB.SuspendLayout();
-            Rashodomer5_GB.SuspendLayout();
-            Rashodomer6_GB.SuspendLayout();
+            Flow1_GB.SuspendLayout();
+            Flow2_GB.SuspendLayout();
+            Flow3_GB.SuspendLayout();
+            Flow4_GB.SuspendLayout();
+            Flow5_GB.SuspendLayout();
+            Flow6_GB.SuspendLayout();
             SuspendLayout();
             // 
             // Flow1_ZavodskNomer_TB
@@ -147,35 +147,35 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow1_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow1_RegistrationNumber_L
+            // Flow1_RegistrationNumber_Label
             //
-            Flow1_RegistrationNumber_L.AutoSize = true;
-            Flow1_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow1_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow1_RegistrationNumber_L.Name = "Flow1_RegistrationNumber_L";
-            Flow1_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow1_RegistrationNumber_L.TabIndex = 26;
-            Flow1_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow1_RegistrationNumber_Label.AutoSize = true;
+            Flow1_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow1_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_RegistrationNumber_Label.Name = "Flow1_RegistrationNumber_Label";
+            Flow1_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow1_RegistrationNumber_Label.TabIndex = 26;
+            Flow1_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label4
+            // Flow1_ZavodskNomer_Label
             //
-            label4.AutoSize = true;
-            label4.Location = new Point(18, 190);
-            label4.Margin = new Padding(4, 0, 4, 0);
-            label4.Name = "label4";
-            label4.Size = new Size(104, 15);
-            label4.TabIndex = 29;
-            label4.Text = "Заводской номер";
+            Flow1_ZavodskNomer_Label.AutoSize = true;
+            Flow1_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow1_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_ZavodskNomer_Label.Name = "Flow1_ZavodskNomer_Label";
+            Flow1_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow1_ZavodskNomer_Label.TabIndex = 29;
+            Flow1_ZavodskNomer_Label.Text = "Заводской номер";
             // 
-            // label3
+            // Flow1_Modification_Label
             // 
-            label3.AutoSize = true;
-            label3.Location = new Point(18, 130);
-            label3.Margin = new Padding(4, 0, 4, 0);
-            label3.Name = "label3";
-            label3.Size = new Size(86, 15);
-            label3.TabIndex = 25;
-            label3.Text = "Модификация";
+            Flow1_Modification_Label.AutoSize = true;
+            Flow1_Modification_Label.Location = new Point(18, 130);
+            Flow1_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_Modification_Label.Name = "Flow1_Modification_Label";
+            Flow1_Modification_Label.Size = new Size(86, 15);
+            Flow1_Modification_Label.TabIndex = 25;
+            Flow1_Modification_Label.Text = "Модификация";
             //
             // Flow1_Modification_CB
             //
@@ -192,15 +192,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Modification_CB.DropDownClosed += RestoreComboText;
             Flow1_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
-            // label2
+            // Flow1_Type_Label
             //
-            label2.AutoSize = true;
-            label2.Location = new Point(18, 40);
-            label2.Margin = new Padding(4, 0, 4, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(28, 15);
-            label2.TabIndex = 21;
-            label2.Text = "Тип";
+            Flow1_Type_Label.AutoSize = true;
+            Flow1_Type_Label.Location = new Point(18, 40);
+            Flow1_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_Type_Label.Name = "Flow1_Type_Label";
+            Flow1_Type_Label.Size = new Size(28, 15);
+            Flow1_Type_Label.TabIndex = 21;
+            Flow1_Type_Label.Text = "Тип";
             // 
             // Flow1_Type_CB
             // 
@@ -216,15 +216,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Type_CB.Click += MeterTypeCB_Click;
             Flow1_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // Flow1_Manufacturer_L
+            // Flow1_Manufacturer_Label
             // 
-            Flow1_Manufacturer_L.AutoSize = true;
-            Flow1_Manufacturer_L.Location = new Point(18, 70);
-            Flow1_Manufacturer_L.Margin = new Padding(4, 0, 4, 0);
-            Flow1_Manufacturer_L.Name = "Flow1_Manufacturer_L";
-            Flow1_Manufacturer_L.Size = new Size(92, 15);
-            Flow1_Manufacturer_L.TabIndex = 23;
-            Flow1_Manufacturer_L.Text = "Производитель";
+            Flow1_Manufacturer_Label.AutoSize = true;
+            Flow1_Manufacturer_Label.Location = new Point(18, 70);
+            Flow1_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_Manufacturer_Label.Name = "Flow1_Manufacturer_Label";
+            Flow1_Manufacturer_Label.Size = new Size(92, 15);
+            Flow1_Manufacturer_Label.TabIndex = 23;
+            Flow1_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow1_Manufacturer_CB
             // 
@@ -256,15 +256,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow1_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow1_ManufactureDate_L
+            // Flow1_ManufactureDate_Label
             //
-            Flow1_ManufactureDate_L.AutoSize = true;
-            Flow1_ManufactureDate_L.Location = new Point(18, 100);
-            Flow1_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow1_ManufactureDate_L.Name = "Flow1_ManufactureDate_L";
-            Flow1_ManufactureDate_L.Size = new Size(111, 15);
-            Flow1_ManufactureDate_L.TabIndex = 24;
-            Flow1_ManufactureDate_L.Text = "Дата изготовления";
+            Flow1_ManufactureDate_Label.AutoSize = true;
+            Flow1_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow1_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_ManufactureDate_Label.Name = "Flow1_ManufactureDate_Label";
+            Flow1_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow1_ManufactureDate_Label.TabIndex = 24;
+            Flow1_ManufactureDate_Label.Text = "Дата изготовления";
             //
             // label1
             //
@@ -277,103 +277,103 @@ namespace PoverkaWinForms.Forms.Verifier
             label1.TabIndex = 19;
             label1.Text = "Настройка параметров поверяемых преобразователей";
             // 
-            // Rashodomer1_GB
+            // Flow1_GB
             // 
-            Rashodomer1_GB.Controls.Add(label8);
-            Rashodomer1_GB.Controls.Add(Rashodomer1_CB);
-            Rashodomer1_GB.Controls.Add(Flow1_Manufacturer_CB);
-            Rashodomer1_GB.Controls.Add(Flow1_ManufactureDate_DTP);
-            Rashodomer1_GB.Controls.Add(Flow1_ManufactureDate_L);
-            Rashodomer1_GB.Controls.Add(Flow1_Manufacturer_L);
-            Rashodomer1_GB.Controls.Add(Flow1_Type_CB);
-            Rashodomer1_GB.Controls.Add(label2);
-            Rashodomer1_GB.Controls.Add(Flow1_Modification_CB);
-            Rashodomer1_GB.Controls.Add(label3);
-            Rashodomer1_GB.Controls.Add(Flow1_RegistrationNumber_TB);
-            Rashodomer1_GB.Controls.Add(Flow1_RegistrationNumber_L);
-            Rashodomer1_GB.Controls.Add(Flow1_ZavodskNomer_TB);
-            Rashodomer1_GB.Controls.Add(label4);
-            Rashodomer1_GB.Location = new Point(60, 56);
-            Rashodomer1_GB.Margin = new Padding(4);
-            Rashodomer1_GB.Name = "Rashodomer1_GB";
-            Rashodomer1_GB.Padding = new Padding(4);
-            Rashodomer1_GB.Size = new Size(342, 281);
-            Rashodomer1_GB.TabIndex = 34;
-            Rashodomer1_GB.TabStop = false;
-            Rashodomer1_GB.Tag = "FirstFlowmeter";
+            Flow1_GB.Controls.Add(Flow1_Title_Label);
+            Flow1_GB.Controls.Add(Flow1_CB);
+            Flow1_GB.Controls.Add(Flow1_Manufacturer_CB);
+            Flow1_GB.Controls.Add(Flow1_ManufactureDate_DTP);
+            Flow1_GB.Controls.Add(Flow1_ManufactureDate_Label);
+            Flow1_GB.Controls.Add(Flow1_Manufacturer_Label);
+            Flow1_GB.Controls.Add(Flow1_Type_CB);
+            Flow1_GB.Controls.Add(Flow1_Type_Label);
+            Flow1_GB.Controls.Add(Flow1_Modification_CB);
+            Flow1_GB.Controls.Add(Flow1_Modification_Label);
+            Flow1_GB.Controls.Add(Flow1_RegistrationNumber_TB);
+            Flow1_GB.Controls.Add(Flow1_RegistrationNumber_Label);
+            Flow1_GB.Controls.Add(Flow1_ZavodskNomer_TB);
+            Flow1_GB.Controls.Add(Flow1_ZavodskNomer_Label);
+            Flow1_GB.Location = new Point(60, 56);
+            Flow1_GB.Margin = new Padding(4);
+            Flow1_GB.Name = "Flow1_GB";
+            Flow1_GB.Padding = new Padding(4);
+            Flow1_GB.Size = new Size(342, 281);
+            Flow1_GB.TabIndex = 34;
+            Flow1_GB.TabStop = false;
+            Flow1_GB.Tag = "FirstFlowmeter";
             // 
-            // label8
+            // Flow1_Title_Label
             // 
-            label8.AutoSize = true;
-            label8.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label8.Location = new Point(18, 0);
-            label8.Margin = new Padding(4, 0, 4, 0);
-            label8.Name = "label8";
-            label8.Size = new Size(156, 24);
-            label8.TabIndex = 35;
-            label8.Text = "Расходомер №1";
+            Flow1_Title_Label.AutoSize = true;
+            Flow1_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow1_Title_Label.Location = new Point(18, 0);
+            Flow1_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow1_Title_Label.Name = "Flow1_Title_Label";
+            Flow1_Title_Label.Size = new Size(156, 24);
+            Flow1_Title_Label.TabIndex = 35;
+            Flow1_Title_Label.Text = "Расходомер №1";
             // 
-            // Rashodomer1_CB
+            // Flow1_CB
             // 
-            Rashodomer1_CB.AutoSize = true;
-            Rashodomer1_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer1_CB.Location = new Point(228, 0);
-            Rashodomer1_CB.Margin = new Padding(4);
-            Rashodomer1_CB.Name = "Rashodomer1_CB";
-            Rashodomer1_CB.Size = new Size(97, 17);
-            Rashodomer1_CB.TabIndex = 36;
-            Rashodomer1_CB.Text = "Установлен";
-            Rashodomer1_CB.UseVisualStyleBackColor = true;
-            Rashodomer1_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow1_CB.AutoSize = true;
+            Flow1_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow1_CB.Location = new Point(228, 0);
+            Flow1_CB.Margin = new Padding(4);
+            Flow1_CB.Name = "Flow1_CB";
+            Flow1_CB.Size = new Size(97, 17);
+            Flow1_CB.TabIndex = 36;
+            Flow1_CB.Text = "Установлен";
+            Flow1_CB.UseVisualStyleBackColor = true;
+            Flow1_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
-            // Rashodomer2_GB
+            // Flow2_GB
             // 
-            Rashodomer2_GB.Controls.Add(label10);
-            Rashodomer2_GB.Controls.Add(Rashodomer2_CB);
-            Rashodomer2_GB.Controls.Add(Flow2_Manufacturer_CB);
-            Rashodomer2_GB.Controls.Add(Flow2_ManufactureDate_DTP);
-            Rashodomer2_GB.Controls.Add(Flow2_ManufactureDate_L);
-            Rashodomer2_GB.Controls.Add(label12);
-            Rashodomer2_GB.Controls.Add(Flow2_Type_CB);
-            Rashodomer2_GB.Controls.Add(label14);
-            Rashodomer2_GB.Controls.Add(Flow2_Modification_CB);
-            Rashodomer2_GB.Controls.Add(label16);
-            Rashodomer2_GB.Controls.Add(Flow2_RegistrationNumber_TB);
-            Rashodomer2_GB.Controls.Add(Flow2_RegistrationNumber_L);
-            Rashodomer2_GB.Controls.Add(Flow2_ZavodskNomer_TB);
-            Rashodomer2_GB.Controls.Add(label17);
-            Rashodomer2_GB.Location = new Point(60, 346);
-            Rashodomer2_GB.Margin = new Padding(4);
-            Rashodomer2_GB.Name = "Rashodomer2_GB";
-            Rashodomer2_GB.Padding = new Padding(4);
-            Rashodomer2_GB.Size = new Size(342, 281);
-            Rashodomer2_GB.TabIndex = 36;
-            Rashodomer2_GB.TabStop = false;
-            Rashodomer2_GB.Tag = "FirstFlowmeter";
+            Flow2_GB.Controls.Add(Flow2_Title_Label);
+            Flow2_GB.Controls.Add(Flow2_CB);
+            Flow2_GB.Controls.Add(Flow2_Manufacturer_CB);
+            Flow2_GB.Controls.Add(Flow2_ManufactureDate_DTP);
+            Flow2_GB.Controls.Add(Flow2_ManufactureDate_Label);
+            Flow2_GB.Controls.Add(Flow2_Manufacturer_Label);
+            Flow2_GB.Controls.Add(Flow2_Type_CB);
+            Flow2_GB.Controls.Add(Flow2_Type_Label);
+            Flow2_GB.Controls.Add(Flow2_Modification_CB);
+            Flow2_GB.Controls.Add(Flow2_Modification_Label);
+            Flow2_GB.Controls.Add(Flow2_RegistrationNumber_TB);
+            Flow2_GB.Controls.Add(Flow2_RegistrationNumber_Label);
+            Flow2_GB.Controls.Add(Flow2_ZavodskNomer_TB);
+            Flow2_GB.Controls.Add(Flow2_ZavodskNomer_Label);
+            Flow2_GB.Location = new Point(60, 346);
+            Flow2_GB.Margin = new Padding(4);
+            Flow2_GB.Name = "Flow2_GB";
+            Flow2_GB.Padding = new Padding(4);
+            Flow2_GB.Size = new Size(342, 281);
+            Flow2_GB.TabIndex = 36;
+            Flow2_GB.TabStop = false;
+            Flow2_GB.Tag = "FirstFlowmeter";
             // 
-            // label10
+            // Flow2_Title_Label
             // 
-            label10.AutoSize = true;
-            label10.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label10.Location = new Point(18, 0);
-            label10.Margin = new Padding(4, 0, 4, 0);
-            label10.Name = "label10";
-            label10.Size = new Size(156, 24);
-            label10.TabIndex = 35;
-            label10.Text = "Расходомер №2";
+            Flow2_Title_Label.AutoSize = true;
+            Flow2_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow2_Title_Label.Location = new Point(18, 0);
+            Flow2_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_Title_Label.Name = "Flow2_Title_Label";
+            Flow2_Title_Label.Size = new Size(156, 24);
+            Flow2_Title_Label.TabIndex = 35;
+            Flow2_Title_Label.Text = "Расходомер №2";
             // 
-            // Rashodomer2_CB
+            // Flow2_CB
             // 
-            Rashodomer2_CB.AutoSize = true;
-            Rashodomer2_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer2_CB.Location = new Point(228, 0);
-            Rashodomer2_CB.Margin = new Padding(4);
-            Rashodomer2_CB.Name = "Rashodomer2_CB";
-            Rashodomer2_CB.Size = new Size(97, 17);
-            Rashodomer2_CB.TabIndex = 45;
-            Rashodomer2_CB.Text = "Установлен";
-            Rashodomer2_CB.UseVisualStyleBackColor = true;
-            Rashodomer2_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow2_CB.AutoSize = true;
+            Flow2_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow2_CB.Location = new Point(228, 0);
+            Flow2_CB.Margin = new Padding(4);
+            Flow2_CB.Name = "Flow2_CB";
+            Flow2_CB.Size = new Size(97, 17);
+            Flow2_CB.TabIndex = 45;
+            Flow2_CB.Text = "Установлен";
+            Flow2_CB.UseVisualStyleBackColor = true;
+            Flow2_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
             // Flow2_Manufacturer_CB
             //
@@ -405,25 +405,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow2_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow2_ManufactureDate_L
+            // Flow2_ManufactureDate_Label
             //
-            Flow2_ManufactureDate_L.AutoSize = true;
-            Flow2_ManufactureDate_L.Location = new Point(18, 100);
-            Flow2_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow2_ManufactureDate_L.Name = "Flow2_ManufactureDate_L";
-            Flow2_ManufactureDate_L.Size = new Size(111, 15);
-            Flow2_ManufactureDate_L.TabIndex = 24;
-            Flow2_ManufactureDate_L.Text = "Дата изготовления";
+            Flow2_ManufactureDate_Label.AutoSize = true;
+            Flow2_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow2_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_ManufactureDate_Label.Name = "Flow2_ManufactureDate_Label";
+            Flow2_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow2_ManufactureDate_Label.TabIndex = 24;
+            Flow2_ManufactureDate_Label.Text = "Дата изготовления";
             //
-            // label12
+            // Flow2_Manufacturer_Label
             //
-            label12.AutoSize = true;
-            label12.Location = new Point(18, 70);
-            label12.Margin = new Padding(4, 0, 4, 0);
-            label12.Name = "label12";
-            label12.Size = new Size(92, 15);
-            label12.TabIndex = 23;
-            label12.Text = "Производитель";
+            Flow2_Manufacturer_Label.AutoSize = true;
+            Flow2_Manufacturer_Label.Location = new Point(18, 70);
+            Flow2_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_Manufacturer_Label.Name = "Flow2_Manufacturer_Label";
+            Flow2_Manufacturer_Label.Size = new Size(92, 15);
+            Flow2_Manufacturer_Label.TabIndex = 23;
+            Flow2_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow2_Type_CB
             //
@@ -439,15 +439,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Type_CB.Click += MeterTypeCB_Click;
             Flow2_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // label14
+            // Flow2_Type_Label
             //
-            label14.AutoSize = true;
-            label14.Location = new Point(18, 40);
-            label14.Margin = new Padding(4, 0, 4, 0);
-            label14.Name = "label14";
-            label14.Size = new Size(28, 15);
-            label14.TabIndex = 21;
-            label14.Text = "Тип";
+            Flow2_Type_Label.AutoSize = true;
+            Flow2_Type_Label.Location = new Point(18, 40);
+            Flow2_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_Type_Label.Name = "Flow2_Type_Label";
+            Flow2_Type_Label.Size = new Size(28, 15);
+            Flow2_Type_Label.TabIndex = 21;
+            Flow2_Type_Label.Text = "Тип";
             //
             // Flow2_Modification_CB
             //
@@ -464,15 +464,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Modification_CB.DropDownClosed += RestoreComboText;
             Flow2_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
-            // label16
+            // Flow2_Modification_Label
             // 
-            label16.AutoSize = true;
-            label16.Location = new Point(18, 130);
-            label16.Margin = new Padding(4, 0, 4, 0);
-            label16.Name = "label16";
-            label16.Size = new Size(86, 15);
-            label16.TabIndex = 25;
-            label16.Text = "Модификация";
+            Flow2_Modification_Label.AutoSize = true;
+            Flow2_Modification_Label.Location = new Point(18, 130);
+            Flow2_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_Modification_Label.Name = "Flow2_Modification_Label";
+            Flow2_Modification_Label.Size = new Size(86, 15);
+            Flow2_Modification_Label.TabIndex = 25;
+            Flow2_Modification_Label.Text = "Модификация";
             // 
             // Flow2_ZavodskNomer_TB
             //
@@ -491,74 +491,74 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow2_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow2_RegistrationNumber_L
+            // Flow2_RegistrationNumber_Label
             //
-            Flow2_RegistrationNumber_L.AutoSize = true;
-            Flow2_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow2_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow2_RegistrationNumber_L.Name = "Flow2_RegistrationNumber_L";
-            Flow2_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow2_RegistrationNumber_L.TabIndex = 26;
-            Flow2_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow2_RegistrationNumber_Label.AutoSize = true;
+            Flow2_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow2_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_RegistrationNumber_Label.Name = "Flow2_RegistrationNumber_Label";
+            Flow2_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow2_RegistrationNumber_Label.TabIndex = 26;
+            Flow2_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label17
+            // Flow2_ZavodskNomer_Label
             //
-            label17.AutoSize = true;
-            label17.Location = new Point(18, 190);
-            label17.Margin = new Padding(4, 0, 4, 0);
-            label17.Name = "label17";
-            label17.Size = new Size(104, 15);
-            label17.TabIndex = 29;
-            label17.Text = "Заводской номер";
+            Flow2_ZavodskNomer_Label.AutoSize = true;
+            Flow2_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow2_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow2_ZavodskNomer_Label.Name = "Flow2_ZavodskNomer_Label";
+            Flow2_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow2_ZavodskNomer_Label.TabIndex = 29;
+            Flow2_ZavodskNomer_Label.Text = "Заводской номер";
             // 
-            // Rashodomer3_GB
+            // Flow3_GB
             // 
-            Rashodomer3_GB.Controls.Add(label9);
-            Rashodomer3_GB.Controls.Add(Rashodomer3_CB);
-            Rashodomer3_GB.Controls.Add(Flow3_Manufacturer_CB);
-            Rashodomer3_GB.Controls.Add(Flow3_ManufactureDate_DTP);
-            Rashodomer3_GB.Controls.Add(Flow3_ManufactureDate_L);
-            Rashodomer3_GB.Controls.Add(label19);
-            Rashodomer3_GB.Controls.Add(Flow3_Type_CB);
-            Rashodomer3_GB.Controls.Add(label21);
-            Rashodomer3_GB.Controls.Add(Flow3_Modification_CB);
-            Rashodomer3_GB.Controls.Add(label23);
-            Rashodomer3_GB.Controls.Add(Flow3_RegistrationNumber_TB);
-            Rashodomer3_GB.Controls.Add(Flow3_RegistrationNumber_L);
-            Rashodomer3_GB.Controls.Add(Flow3_ZavodskNomer_TB);
-            Rashodomer3_GB.Controls.Add(label24);
-            Rashodomer3_GB.Location = new Point(409, 56);
-            Rashodomer3_GB.Margin = new Padding(4);
-            Rashodomer3_GB.Name = "Rashodomer3_GB";
-            Rashodomer3_GB.Padding = new Padding(4);
-            Rashodomer3_GB.Size = new Size(342, 281);
-            Rashodomer3_GB.TabIndex = 37;
-            Rashodomer3_GB.TabStop = false;
-            Rashodomer3_GB.Tag = "FirstFlowmeter";
+            Flow3_GB.Controls.Add(Flow3_Title_Label);
+            Flow3_GB.Controls.Add(Flow3_CB);
+            Flow3_GB.Controls.Add(Flow3_Manufacturer_CB);
+            Flow3_GB.Controls.Add(Flow3_ManufactureDate_DTP);
+            Flow3_GB.Controls.Add(Flow3_ManufactureDate_Label);
+            Flow3_GB.Controls.Add(Flow3_Manufacturer_Label);
+            Flow3_GB.Controls.Add(Flow3_Type_CB);
+            Flow3_GB.Controls.Add(Flow3_Type_Label);
+            Flow3_GB.Controls.Add(Flow3_Modification_CB);
+            Flow3_GB.Controls.Add(Flow3_Modification_Label);
+            Flow3_GB.Controls.Add(Flow3_RegistrationNumber_TB);
+            Flow3_GB.Controls.Add(Flow3_RegistrationNumber_Label);
+            Flow3_GB.Controls.Add(Flow3_ZavodskNomer_TB);
+            Flow3_GB.Controls.Add(Flow3_ZavodskNomer_Label);
+            Flow3_GB.Location = new Point(409, 56);
+            Flow3_GB.Margin = new Padding(4);
+            Flow3_GB.Name = "Flow3_GB";
+            Flow3_GB.Padding = new Padding(4);
+            Flow3_GB.Size = new Size(342, 281);
+            Flow3_GB.TabIndex = 37;
+            Flow3_GB.TabStop = false;
+            Flow3_GB.Tag = "FirstFlowmeter";
             // 
-            // label9
+            // Flow3_Title_Label
             // 
-            label9.AutoSize = true;
-            label9.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label9.Location = new Point(18, 0);
-            label9.Margin = new Padding(4, 0, 4, 0);
-            label9.Name = "label9";
-            label9.Size = new Size(156, 24);
-            label9.TabIndex = 35;
-            label9.Text = "Расходомер №3";
+            Flow3_Title_Label.AutoSize = true;
+            Flow3_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow3_Title_Label.Location = new Point(18, 0);
+            Flow3_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_Title_Label.Name = "Flow3_Title_Label";
+            Flow3_Title_Label.Size = new Size(156, 24);
+            Flow3_Title_Label.TabIndex = 35;
+            Flow3_Title_Label.Text = "Расходомер №3";
             // 
-            // Rashodomer3_CB
+            // Flow3_CB
             // 
-            Rashodomer3_CB.AutoSize = true;
-            Rashodomer3_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer3_CB.Location = new Point(228, 0);
-            Rashodomer3_CB.Margin = new Padding(4);
-            Rashodomer3_CB.Name = "Rashodomer3_CB";
-            Rashodomer3_CB.Size = new Size(97, 17);
-            Rashodomer3_CB.TabIndex = 46;
-            Rashodomer3_CB.Text = "Установлен";
-            Rashodomer3_CB.UseVisualStyleBackColor = true;
-            Rashodomer3_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow3_CB.AutoSize = true;
+            Flow3_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow3_CB.Location = new Point(228, 0);
+            Flow3_CB.Margin = new Padding(4);
+            Flow3_CB.Name = "Flow3_CB";
+            Flow3_CB.Size = new Size(97, 17);
+            Flow3_CB.TabIndex = 46;
+            Flow3_CB.Text = "Установлен";
+            Flow3_CB.UseVisualStyleBackColor = true;
+            Flow3_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
             // Flow3_Manufacturer_CB
             //
@@ -590,25 +590,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow3_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow3_ManufactureDate_L
+            // Flow3_ManufactureDate_Label
             //
-            Flow3_ManufactureDate_L.AutoSize = true;
-            Flow3_ManufactureDate_L.Location = new Point(18, 100);
-            Flow3_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow3_ManufactureDate_L.Name = "Flow3_ManufactureDate_L";
-            Flow3_ManufactureDate_L.Size = new Size(111, 15);
-            Flow3_ManufactureDate_L.TabIndex = 24;
-            Flow3_ManufactureDate_L.Text = "Дата изготовления";
+            Flow3_ManufactureDate_Label.AutoSize = true;
+            Flow3_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow3_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_ManufactureDate_Label.Name = "Flow3_ManufactureDate_Label";
+            Flow3_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow3_ManufactureDate_Label.TabIndex = 24;
+            Flow3_ManufactureDate_Label.Text = "Дата изготовления";
             //
-            // label19
+            // Flow3_Manufacturer_Label
             //
-            label19.AutoSize = true;
-            label19.Location = new Point(18, 70);
-            label19.Margin = new Padding(4, 0, 4, 0);
-            label19.Name = "label19";
-            label19.Size = new Size(92, 15);
-            label19.TabIndex = 23;
-            label19.Text = "Производитель";
+            Flow3_Manufacturer_Label.AutoSize = true;
+            Flow3_Manufacturer_Label.Location = new Point(18, 70);
+            Flow3_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_Manufacturer_Label.Name = "Flow3_Manufacturer_Label";
+            Flow3_Manufacturer_Label.Size = new Size(92, 15);
+            Flow3_Manufacturer_Label.TabIndex = 23;
+            Flow3_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow3_Type_CB
             //
@@ -624,15 +624,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Type_CB.Click += MeterTypeCB_Click;
             Flow3_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // label21
+            // Flow3_Type_Label
             //
-            label21.AutoSize = true;
-            label21.Location = new Point(18, 40);
-            label21.Margin = new Padding(4, 0, 4, 0);
-            label21.Name = "label21";
-            label21.Size = new Size(28, 15);
-            label21.TabIndex = 21;
-            label21.Text = "Тип";
+            Flow3_Type_Label.AutoSize = true;
+            Flow3_Type_Label.Location = new Point(18, 40);
+            Flow3_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_Type_Label.Name = "Flow3_Type_Label";
+            Flow3_Type_Label.Size = new Size(28, 15);
+            Flow3_Type_Label.TabIndex = 21;
+            Flow3_Type_Label.Text = "Тип";
             // 
             // Flow3_Modification_CB
             //
@@ -649,15 +649,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Modification_CB.DropDownClosed += RestoreComboText;
             Flow3_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
-            // label23
+            // Flow3_Modification_Label
             // 
-            label23.AutoSize = true;
-            label23.Location = new Point(18, 130);
-            label23.Margin = new Padding(4, 0, 4, 0);
-            label23.Name = "label23";
-            label23.Size = new Size(86, 15);
-            label23.TabIndex = 25;
-            label23.Text = "Модификация";
+            Flow3_Modification_Label.AutoSize = true;
+            Flow3_Modification_Label.Location = new Point(18, 130);
+            Flow3_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_Modification_Label.Name = "Flow3_Modification_Label";
+            Flow3_Modification_Label.Size = new Size(86, 15);
+            Flow3_Modification_Label.TabIndex = 25;
+            Flow3_Modification_Label.Text = "Модификация";
             // 
             // Flow3_ZavodskNomer_TB
             //
@@ -676,74 +676,74 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow3_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow3_RegistrationNumber_L
+            // Flow3_RegistrationNumber_Label
             //
-            Flow3_RegistrationNumber_L.AutoSize = true;
-            Flow3_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow3_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow3_RegistrationNumber_L.Name = "Flow3_RegistrationNumber_L";
-            Flow3_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow3_RegistrationNumber_L.TabIndex = 26;
-            Flow3_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow3_RegistrationNumber_Label.AutoSize = true;
+            Flow3_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow3_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_RegistrationNumber_Label.Name = "Flow3_RegistrationNumber_Label";
+            Flow3_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow3_RegistrationNumber_Label.TabIndex = 26;
+            Flow3_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label24
+            // Flow3_ZavodskNomer_Label
             //
-            label24.AutoSize = true;
-            label24.Location = new Point(18, 190);
-            label24.Margin = new Padding(4, 0, 4, 0);
-            label24.Name = "label24";
-            label24.Size = new Size(104, 15);
-            label24.TabIndex = 29;
-            label24.Text = "Заводской номер";
+            Flow3_ZavodskNomer_Label.AutoSize = true;
+            Flow3_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow3_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow3_ZavodskNomer_Label.Name = "Flow3_ZavodskNomer_Label";
+            Flow3_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow3_ZavodskNomer_Label.TabIndex = 29;
+            Flow3_ZavodskNomer_Label.Text = "Заводской номер";
             // 
-            // Rashodomer4_GB
+            // Flow4_GB
             // 
-            Rashodomer4_GB.Controls.Add(label25);
-            Rashodomer4_GB.Controls.Add(Rashodomer4_CB);
-            Rashodomer4_GB.Controls.Add(Flow4_Manufacturer_CB);
-            Rashodomer4_GB.Controls.Add(Flow4_ManufactureDate_DTP);
-            Rashodomer4_GB.Controls.Add(Flow4_ManufactureDate_L);
-            Rashodomer4_GB.Controls.Add(label27);
-            Rashodomer4_GB.Controls.Add(Flow4_Type_CB);
-            Rashodomer4_GB.Controls.Add(label29);
-            Rashodomer4_GB.Controls.Add(Flow4_Modification_CB);
-            Rashodomer4_GB.Controls.Add(label31);
-            Rashodomer4_GB.Controls.Add(Flow4_RegistrationNumber_TB);
-            Rashodomer4_GB.Controls.Add(Flow4_RegistrationNumber_L);
-            Rashodomer4_GB.Controls.Add(Flow4_ZavodskNomer_TB);
-            Rashodomer4_GB.Controls.Add(label32);
-            Rashodomer4_GB.Location = new Point(409, 346);
-            Rashodomer4_GB.Margin = new Padding(4);
-            Rashodomer4_GB.Name = "Rashodomer4_GB";
-            Rashodomer4_GB.Padding = new Padding(4);
-            Rashodomer4_GB.Size = new Size(342, 281);
-            Rashodomer4_GB.TabIndex = 38;
-            Rashodomer4_GB.TabStop = false;
-            Rashodomer4_GB.Tag = "FirstFlowmeter";
+            Flow4_GB.Controls.Add(Flow4_Title_Label);
+            Flow4_GB.Controls.Add(Flow4_CB);
+            Flow4_GB.Controls.Add(Flow4_Manufacturer_CB);
+            Flow4_GB.Controls.Add(Flow4_ManufactureDate_DTP);
+            Flow4_GB.Controls.Add(Flow4_ManufactureDate_Label);
+            Flow4_GB.Controls.Add(Flow4_Manufacturer_Label);
+            Flow4_GB.Controls.Add(Flow4_Type_CB);
+            Flow4_GB.Controls.Add(Flow4_Type_Label);
+            Flow4_GB.Controls.Add(Flow4_Modification_CB);
+            Flow4_GB.Controls.Add(Flow4_Modification_Label);
+            Flow4_GB.Controls.Add(Flow4_RegistrationNumber_TB);
+            Flow4_GB.Controls.Add(Flow4_RegistrationNumber_Label);
+            Flow4_GB.Controls.Add(Flow4_ZavodskNomer_TB);
+            Flow4_GB.Controls.Add(Flow4_ZavodskNomer_Label);
+            Flow4_GB.Location = new Point(409, 346);
+            Flow4_GB.Margin = new Padding(4);
+            Flow4_GB.Name = "Flow4_GB";
+            Flow4_GB.Padding = new Padding(4);
+            Flow4_GB.Size = new Size(342, 281);
+            Flow4_GB.TabIndex = 38;
+            Flow4_GB.TabStop = false;
+            Flow4_GB.Tag = "FirstFlowmeter";
             // 
-            // label25
+            // Flow4_Title_Label
             // 
-            label25.AutoSize = true;
-            label25.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label25.Location = new Point(18, 0);
-            label25.Margin = new Padding(4, 0, 4, 0);
-            label25.Name = "label25";
-            label25.Size = new Size(156, 24);
-            label25.TabIndex = 35;
-            label25.Text = "Расходомер №4";
+            Flow4_Title_Label.AutoSize = true;
+            Flow4_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow4_Title_Label.Location = new Point(18, 0);
+            Flow4_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_Title_Label.Name = "Flow4_Title_Label";
+            Flow4_Title_Label.Size = new Size(156, 24);
+            Flow4_Title_Label.TabIndex = 35;
+            Flow4_Title_Label.Text = "Расходомер №4";
             // 
-            // Rashodomer4_CB
+            // Flow4_CB
             // 
-            Rashodomer4_CB.AutoSize = true;
-            Rashodomer4_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer4_CB.Location = new Point(228, 0);
-            Rashodomer4_CB.Margin = new Padding(4);
-            Rashodomer4_CB.Name = "Rashodomer4_CB";
-            Rashodomer4_CB.Size = new Size(97, 17);
-            Rashodomer4_CB.TabIndex = 47;
-            Rashodomer4_CB.Text = "Установлен";
-            Rashodomer4_CB.UseVisualStyleBackColor = true;
-            Rashodomer4_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow4_CB.AutoSize = true;
+            Flow4_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow4_CB.Location = new Point(228, 0);
+            Flow4_CB.Margin = new Padding(4);
+            Flow4_CB.Name = "Flow4_CB";
+            Flow4_CB.Size = new Size(97, 17);
+            Flow4_CB.TabIndex = 47;
+            Flow4_CB.Text = "Установлен";
+            Flow4_CB.UseVisualStyleBackColor = true;
+            Flow4_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
             // Flow4_Manufacturer_CB
             //
@@ -775,25 +775,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow4_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow4_ManufactureDate_L
+            // Flow4_ManufactureDate_Label
             //
-            Flow4_ManufactureDate_L.AutoSize = true;
-            Flow4_ManufactureDate_L.Location = new Point(18, 100);
-            Flow4_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow4_ManufactureDate_L.Name = "Flow4_ManufactureDate_L";
-            Flow4_ManufactureDate_L.Size = new Size(111, 15);
-            Flow4_ManufactureDate_L.TabIndex = 24;
-            Flow4_ManufactureDate_L.Text = "Дата изготовления";
+            Flow4_ManufactureDate_Label.AutoSize = true;
+            Flow4_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow4_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_ManufactureDate_Label.Name = "Flow4_ManufactureDate_Label";
+            Flow4_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow4_ManufactureDate_Label.TabIndex = 24;
+            Flow4_ManufactureDate_Label.Text = "Дата изготовления";
             //
-            // label27
+            // Flow4_Manufacturer_Label
             //
-            label27.AutoSize = true;
-            label27.Location = new Point(18, 70);
-            label27.Margin = new Padding(4, 0, 4, 0);
-            label27.Name = "label27";
-            label27.Size = new Size(92, 15);
-            label27.TabIndex = 23;
-            label27.Text = "Производитель";
+            Flow4_Manufacturer_Label.AutoSize = true;
+            Flow4_Manufacturer_Label.Location = new Point(18, 70);
+            Flow4_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_Manufacturer_Label.Name = "Flow4_Manufacturer_Label";
+            Flow4_Manufacturer_Label.Size = new Size(92, 15);
+            Flow4_Manufacturer_Label.TabIndex = 23;
+            Flow4_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow4_Type_CB
             //
@@ -809,15 +809,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Type_CB.Click += MeterTypeCB_Click;
             Flow4_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // label29
+            // Flow4_Type_Label
             //
-            label29.AutoSize = true;
-            label29.Location = new Point(18, 40);
-            label29.Margin = new Padding(4, 0, 4, 0);
-            label29.Name = "label29";
-            label29.Size = new Size(117, 15);
-            label29.TabIndex = 21;
-            label29.Text = "Тип";
+            Flow4_Type_Label.AutoSize = true;
+            Flow4_Type_Label.Location = new Point(18, 40);
+            Flow4_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_Type_Label.Name = "Flow4_Type_Label";
+            Flow4_Type_Label.Size = new Size(117, 15);
+            Flow4_Type_Label.TabIndex = 21;
+            Flow4_Type_Label.Text = "Тип";
             // 
             // Flow4_Modification_CB
             //
@@ -834,15 +834,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Modification_CB.DropDownClosed += RestoreComboText;
             Flow4_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
-            // label31
+            // Flow4_Modification_Label
             // 
-            label31.AutoSize = true;
-            label31.Location = new Point(18, 130);
-            label31.Margin = new Padding(4, 0, 4, 0);
-            label31.Name = "label31";
-            label31.Size = new Size(86, 15);
-            label31.TabIndex = 25;
-            label31.Text = "Модификация";
+            Flow4_Modification_Label.AutoSize = true;
+            Flow4_Modification_Label.Location = new Point(18, 130);
+            Flow4_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_Modification_Label.Name = "Flow4_Modification_Label";
+            Flow4_Modification_Label.Size = new Size(86, 15);
+            Flow4_Modification_Label.TabIndex = 25;
+            Flow4_Modification_Label.Text = "Модификация";
             // 
             // Flow4_ZavodskNomer_TB
             //
@@ -861,74 +861,74 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow4_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow4_RegistrationNumber_L
+            // Flow4_RegistrationNumber_Label
             //
-            Flow4_RegistrationNumber_L.AutoSize = true;
-            Flow4_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow4_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow4_RegistrationNumber_L.Name = "Flow4_RegistrationNumber_L";
-            Flow4_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow4_RegistrationNumber_L.TabIndex = 26;
-            Flow4_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow4_RegistrationNumber_Label.AutoSize = true;
+            Flow4_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow4_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_RegistrationNumber_Label.Name = "Flow4_RegistrationNumber_Label";
+            Flow4_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow4_RegistrationNumber_Label.TabIndex = 26;
+            Flow4_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label32
+            // Flow4_ZavodskNomer_Label
             //
-            label32.AutoSize = true;
-            label32.Location = new Point(18, 190);
-            label32.Margin = new Padding(4, 0, 4, 0);
-            label32.Name = "label32";
-            label32.Size = new Size(104, 15);
-            label32.TabIndex = 29;
-            label32.Text = "Заводской номер";
+            Flow4_ZavodskNomer_Label.AutoSize = true;
+            Flow4_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow4_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow4_ZavodskNomer_Label.Name = "Flow4_ZavodskNomer_Label";
+            Flow4_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow4_ZavodskNomer_Label.TabIndex = 29;
+            Flow4_ZavodskNomer_Label.Text = "Заводской номер";
             // 
-            // Rashodomer5_GB
+            // Flow5_GB
             // 
-            Rashodomer5_GB.Controls.Add(label33);
-            Rashodomer5_GB.Controls.Add(Rashodomer5_CB);
-            Rashodomer5_GB.Controls.Add(Flow5_Manufacturer_CB);
-            Rashodomer5_GB.Controls.Add(Flow5_ManufactureDate_DTP);
-            Rashodomer5_GB.Controls.Add(Flow5_ManufactureDate_L);
-            Rashodomer5_GB.Controls.Add(label35);
-            Rashodomer5_GB.Controls.Add(Flow5_Type_CB);
-            Rashodomer5_GB.Controls.Add(label37);
-            Rashodomer5_GB.Controls.Add(Flow5_Modification_CB);
-            Rashodomer5_GB.Controls.Add(label39);
-            Rashodomer5_GB.Controls.Add(Flow5_RegistrationNumber_TB);
-            Rashodomer5_GB.Controls.Add(Flow5_RegistrationNumber_L);
-            Rashodomer5_GB.Controls.Add(Flow5_ZavodskNomer_TB);
-            Rashodomer5_GB.Controls.Add(label40);
-            Rashodomer5_GB.Location = new Point(757, 56);
-            Rashodomer5_GB.Margin = new Padding(4);
-            Rashodomer5_GB.Name = "Rashodomer5_GB";
-            Rashodomer5_GB.Padding = new Padding(4);
-            Rashodomer5_GB.Size = new Size(342, 281);
-            Rashodomer5_GB.TabIndex = 37;
-            Rashodomer5_GB.TabStop = false;
-            Rashodomer5_GB.Tag = "FirstFlowmeter";
+            Flow5_GB.Controls.Add(Flow5_Title_Label);
+            Flow5_GB.Controls.Add(Flow5_CB);
+            Flow5_GB.Controls.Add(Flow5_Manufacturer_CB);
+            Flow5_GB.Controls.Add(Flow5_ManufactureDate_DTP);
+            Flow5_GB.Controls.Add(Flow5_ManufactureDate_Label);
+            Flow5_GB.Controls.Add(Flow5_Manufacturer_Label);
+            Flow5_GB.Controls.Add(Flow5_Type_CB);
+            Flow5_GB.Controls.Add(Flow5_Type_Label);
+            Flow5_GB.Controls.Add(Flow5_Modification_CB);
+            Flow5_GB.Controls.Add(Flow5_Modification_Label);
+            Flow5_GB.Controls.Add(Flow5_RegistrationNumber_TB);
+            Flow5_GB.Controls.Add(Flow5_RegistrationNumber_Label);
+            Flow5_GB.Controls.Add(Flow5_ZavodskNomer_TB);
+            Flow5_GB.Controls.Add(Flow5_ZavodskNomer_Label);
+            Flow5_GB.Location = new Point(757, 56);
+            Flow5_GB.Margin = new Padding(4);
+            Flow5_GB.Name = "Flow5_GB";
+            Flow5_GB.Padding = new Padding(4);
+            Flow5_GB.Size = new Size(342, 281);
+            Flow5_GB.TabIndex = 37;
+            Flow5_GB.TabStop = false;
+            Flow5_GB.Tag = "FirstFlowmeter";
             // 
-            // label33
+            // Flow5_Title_Label
             // 
-            label33.AutoSize = true;
-            label33.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label33.Location = new Point(18, 0);
-            label33.Margin = new Padding(4, 0, 4, 0);
-            label33.Name = "label33";
-            label33.Size = new Size(156, 24);
-            label33.TabIndex = 35;
-            label33.Text = "Расходомер №5";
+            Flow5_Title_Label.AutoSize = true;
+            Flow5_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow5_Title_Label.Location = new Point(18, 0);
+            Flow5_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_Title_Label.Name = "Flow5_Title_Label";
+            Flow5_Title_Label.Size = new Size(156, 24);
+            Flow5_Title_Label.TabIndex = 35;
+            Flow5_Title_Label.Text = "Расходомер №5";
             // 
-            // Rashodomer5_CB
+            // Flow5_CB
             // 
-            Rashodomer5_CB.AutoSize = true;
-            Rashodomer5_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer5_CB.Location = new Point(228, 0);
-            Rashodomer5_CB.Margin = new Padding(4);
-            Rashodomer5_CB.Name = "Rashodomer5_CB";
-            Rashodomer5_CB.Size = new Size(97, 17);
-            Rashodomer5_CB.TabIndex = 48;
-            Rashodomer5_CB.Text = "Установлен";
-            Rashodomer5_CB.UseVisualStyleBackColor = true;
-            Rashodomer5_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow5_CB.AutoSize = true;
+            Flow5_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow5_CB.Location = new Point(228, 0);
+            Flow5_CB.Margin = new Padding(4);
+            Flow5_CB.Name = "Flow5_CB";
+            Flow5_CB.Size = new Size(97, 17);
+            Flow5_CB.TabIndex = 48;
+            Flow5_CB.Text = "Установлен";
+            Flow5_CB.UseVisualStyleBackColor = true;
+            Flow5_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
             // Flow5_Manufacturer_CB
             //
@@ -960,25 +960,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow5_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow5_ManufactureDate_L
+            // Flow5_ManufactureDate_Label
             //
-            Flow5_ManufactureDate_L.AutoSize = true;
-            Flow5_ManufactureDate_L.Location = new Point(18, 100);
-            Flow5_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow5_ManufactureDate_L.Name = "Flow5_ManufactureDate_L";
-            Flow5_ManufactureDate_L.Size = new Size(111, 15);
-            Flow5_ManufactureDate_L.TabIndex = 24;
-            Flow5_ManufactureDate_L.Text = "Дата изготовления";
+            Flow5_ManufactureDate_Label.AutoSize = true;
+            Flow5_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow5_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_ManufactureDate_Label.Name = "Flow5_ManufactureDate_Label";
+            Flow5_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow5_ManufactureDate_Label.TabIndex = 24;
+            Flow5_ManufactureDate_Label.Text = "Дата изготовления";
             //
-            // label35
+            // Flow5_Manufacturer_Label
             //
-            label35.AutoSize = true;
-            label35.Location = new Point(18, 70);
-            label35.Margin = new Padding(4, 0, 4, 0);
-            label35.Name = "label35";
-            label35.Size = new Size(92, 15);
-            label35.TabIndex = 23;
-            label35.Text = "Производитель";
+            Flow5_Manufacturer_Label.AutoSize = true;
+            Flow5_Manufacturer_Label.Location = new Point(18, 70);
+            Flow5_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_Manufacturer_Label.Name = "Flow5_Manufacturer_Label";
+            Flow5_Manufacturer_Label.Size = new Size(92, 15);
+            Flow5_Manufacturer_Label.TabIndex = 23;
+            Flow5_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow5_Type_CB
             //
@@ -994,15 +994,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Type_CB.Click += MeterTypeCB_Click;
             Flow5_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // label37
+            // Flow5_Type_Label
             //
-            label37.AutoSize = true;
-            label37.Location = new Point(18, 40);
-            label37.Margin = new Padding(4, 0, 4, 0);
-            label37.Name = "label37";
-            label37.Size = new Size(28, 15);
-            label37.TabIndex = 21;
-            label37.Text = "Тип";
+            Flow5_Type_Label.AutoSize = true;
+            Flow5_Type_Label.Location = new Point(18, 40);
+            Flow5_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_Type_Label.Name = "Flow5_Type_Label";
+            Flow5_Type_Label.Size = new Size(28, 15);
+            Flow5_Type_Label.TabIndex = 21;
+            Flow5_Type_Label.Text = "Тип";
             // 
             // Flow5_Modification_CB
             //
@@ -1019,15 +1019,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Modification_CB.DropDownClosed += RestoreComboText;
             Flow5_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
-            // label39
+            // Flow5_Modification_Label
             // 
-            label39.AutoSize = true;
-            label39.Location = new Point(18, 130);
-            label39.Margin = new Padding(4, 0, 4, 0);
-            label39.Name = "label39";
-            label39.Size = new Size(86, 15);
-            label39.TabIndex = 25;
-            label39.Text = "Модификация";
+            Flow5_Modification_Label.AutoSize = true;
+            Flow5_Modification_Label.Location = new Point(18, 130);
+            Flow5_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_Modification_Label.Name = "Flow5_Modification_Label";
+            Flow5_Modification_Label.Size = new Size(86, 15);
+            Flow5_Modification_Label.TabIndex = 25;
+            Flow5_Modification_Label.Text = "Модификация";
             // 
             // Flow5_ZavodskNomer_TB
             //
@@ -1046,74 +1046,74 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow5_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow5_RegistrationNumber_L
+            // Flow5_RegistrationNumber_Label
             //
-            Flow5_RegistrationNumber_L.AutoSize = true;
-            Flow5_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow5_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow5_RegistrationNumber_L.Name = "Flow5_RegistrationNumber_L";
-            Flow5_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow5_RegistrationNumber_L.TabIndex = 26;
-            Flow5_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow5_RegistrationNumber_Label.AutoSize = true;
+            Flow5_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow5_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_RegistrationNumber_Label.Name = "Flow5_RegistrationNumber_Label";
+            Flow5_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow5_RegistrationNumber_Label.TabIndex = 26;
+            Flow5_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label40
+            // Flow5_ZavodskNomer_Label
             //
-            label40.AutoSize = true;
-            label40.Location = new Point(18, 190);
-            label40.Margin = new Padding(4, 0, 4, 0);
-            label40.Name = "label40";
-            label40.Size = new Size(104, 15);
-            label40.TabIndex = 29;
-            label40.Text = "Заводской номер";
+            Flow5_ZavodskNomer_Label.AutoSize = true;
+            Flow5_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow5_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow5_ZavodskNomer_Label.Name = "Flow5_ZavodskNomer_Label";
+            Flow5_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow5_ZavodskNomer_Label.TabIndex = 29;
+            Flow5_ZavodskNomer_Label.Text = "Заводской номер";
             // 
-            // Rashodomer6_GB
+            // Flow6_GB
             // 
-            Rashodomer6_GB.Controls.Add(label41);
-            Rashodomer6_GB.Controls.Add(Rashodomer6_CB);
-            Rashodomer6_GB.Controls.Add(Flow6_Manufacturer_CB);
-            Rashodomer6_GB.Controls.Add(Flow6_ManufactureDate_DTP);
-            Rashodomer6_GB.Controls.Add(Flow6_ManufactureDate_L);
-            Rashodomer6_GB.Controls.Add(label43);
-            Rashodomer6_GB.Controls.Add(Flow6_Type_CB);
-            Rashodomer6_GB.Controls.Add(label45);
-            Rashodomer6_GB.Controls.Add(Flow6_Modification_CB);
-            Rashodomer6_GB.Controls.Add(label47);
-            Rashodomer6_GB.Controls.Add(Flow6_RegistrationNumber_TB);
-            Rashodomer6_GB.Controls.Add(Flow6_RegistrationNumber_L);
-            Rashodomer6_GB.Controls.Add(Flow6_ZavodskNomer_TB);
-            Rashodomer6_GB.Controls.Add(label48);
-            Rashodomer6_GB.Location = new Point(757, 346);
-            Rashodomer6_GB.Margin = new Padding(4);
-            Rashodomer6_GB.Name = "Rashodomer6_GB";
-            Rashodomer6_GB.Padding = new Padding(4);
-            Rashodomer6_GB.Size = new Size(342, 281);
-            Rashodomer6_GB.TabIndex = 37;
-            Rashodomer6_GB.TabStop = false;
-            Rashodomer6_GB.Tag = "FirstFlowmeter";
+            Flow6_GB.Controls.Add(Flow6_Title_Label);
+            Flow6_GB.Controls.Add(Flow6_CB);
+            Flow6_GB.Controls.Add(Flow6_Manufacturer_CB);
+            Flow6_GB.Controls.Add(Flow6_ManufactureDate_DTP);
+            Flow6_GB.Controls.Add(Flow6_ManufactureDate_Label);
+            Flow6_GB.Controls.Add(Flow6_Manufacturer_Label);
+            Flow6_GB.Controls.Add(Flow6_Type_CB);
+            Flow6_GB.Controls.Add(Flow6_Type_Label);
+            Flow6_GB.Controls.Add(Flow6_Modification_CB);
+            Flow6_GB.Controls.Add(Flow6_Modification_Label);
+            Flow6_GB.Controls.Add(Flow6_RegistrationNumber_TB);
+            Flow6_GB.Controls.Add(Flow6_RegistrationNumber_Label);
+            Flow6_GB.Controls.Add(Flow6_ZavodskNomer_TB);
+            Flow6_GB.Controls.Add(Flow6_ZavodskNomer_Label);
+            Flow6_GB.Location = new Point(757, 346);
+            Flow6_GB.Margin = new Padding(4);
+            Flow6_GB.Name = "Flow6_GB";
+            Flow6_GB.Padding = new Padding(4);
+            Flow6_GB.Size = new Size(342, 281);
+            Flow6_GB.TabIndex = 37;
+            Flow6_GB.TabStop = false;
+            Flow6_GB.Tag = "FirstFlowmeter";
             // 
-            // label41
+            // Flow6_Title_Label
             // 
-            label41.AutoSize = true;
-            label41.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label41.Location = new Point(18, 0);
-            label41.Margin = new Padding(4, 0, 4, 0);
-            label41.Name = "label41";
-            label41.Size = new Size(156, 24);
-            label41.TabIndex = 35;
-            label41.Text = "Расходомер №6";
+            Flow6_Title_Label.AutoSize = true;
+            Flow6_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow6_Title_Label.Location = new Point(18, 0);
+            Flow6_Title_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_Title_Label.Name = "Flow6_Title_Label";
+            Flow6_Title_Label.Size = new Size(156, 24);
+            Flow6_Title_Label.TabIndex = 35;
+            Flow6_Title_Label.Text = "Расходомер №6";
             // 
-            // Rashodomer6_CB
+            // Flow6_CB
             // 
-            Rashodomer6_CB.AutoSize = true;
-            Rashodomer6_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Rashodomer6_CB.Location = new Point(228, 0);
-            Rashodomer6_CB.Margin = new Padding(4);
-            Rashodomer6_CB.Name = "Rashodomer6_CB";
-            Rashodomer6_CB.Size = new Size(97, 17);
-            Rashodomer6_CB.TabIndex = 49;
-            Rashodomer6_CB.Text = "Установлен";
-            Rashodomer6_CB.UseVisualStyleBackColor = true;
-            Rashodomer6_CB.CheckedChanged += RashodomerCB_CheckedChanged;
+            Flow6_CB.AutoSize = true;
+            Flow6_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow6_CB.Location = new Point(228, 0);
+            Flow6_CB.Margin = new Padding(4);
+            Flow6_CB.Name = "Flow6_CB";
+            Flow6_CB.Size = new Size(97, 17);
+            Flow6_CB.TabIndex = 49;
+            Flow6_CB.Text = "Установлен";
+            Flow6_CB.UseVisualStyleBackColor = true;
+            Flow6_CB.CheckedChanged += FlowCB_CheckedChanged;
             // 
             // Flow6_Manufacturer_CB
             //
@@ -1145,25 +1145,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
             Flow6_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
-            // Flow6_ManufactureDate_L
+            // Flow6_ManufactureDate_Label
             //
-            Flow6_ManufactureDate_L.AutoSize = true;
-            Flow6_ManufactureDate_L.Location = new Point(18, 100);
-            Flow6_ManufactureDate_L.Margin = new Padding(4, 0, 4, 0);
-            Flow6_ManufactureDate_L.Name = "Flow6_ManufactureDate_L";
-            Flow6_ManufactureDate_L.Size = new Size(111, 15);
-            Flow6_ManufactureDate_L.TabIndex = 24;
-            Flow6_ManufactureDate_L.Text = "Дата изготовления";
+            Flow6_ManufactureDate_Label.AutoSize = true;
+            Flow6_ManufactureDate_Label.Location = new Point(18, 100);
+            Flow6_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_ManufactureDate_Label.Name = "Flow6_ManufactureDate_Label";
+            Flow6_ManufactureDate_Label.Size = new Size(111, 15);
+            Flow6_ManufactureDate_Label.TabIndex = 24;
+            Flow6_ManufactureDate_Label.Text = "Дата изготовления";
             //
-            // label43
+            // Flow6_Manufacturer_Label
             //
-            label43.AutoSize = true;
-            label43.Location = new Point(18, 70);
-            label43.Margin = new Padding(4, 0, 4, 0);
-            label43.Name = "label43";
-            label43.Size = new Size(92, 15);
-            label43.TabIndex = 23;
-            label43.Text = "Производитель";
+            Flow6_Manufacturer_Label.AutoSize = true;
+            Flow6_Manufacturer_Label.Location = new Point(18, 70);
+            Flow6_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_Manufacturer_Label.Name = "Flow6_Manufacturer_Label";
+            Flow6_Manufacturer_Label.Size = new Size(92, 15);
+            Flow6_Manufacturer_Label.TabIndex = 23;
+            Flow6_Manufacturer_Label.Text = "Производитель";
             // 
             // Flow6_Type_CB
             //
@@ -1179,15 +1179,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Type_CB.Click += MeterTypeCB_Click;
             Flow6_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // label45
+            // Flow6_Type_Label
             //
-            label45.AutoSize = true;
-            label45.Location = new Point(18, 40);
-            label45.Margin = new Padding(4, 0, 4, 0);
-            label45.Name = "label45";
-            label45.Size = new Size(28, 15);
-            label45.TabIndex = 21;
-            label45.Text = "Тип";
+            Flow6_Type_Label.AutoSize = true;
+            Flow6_Type_Label.Location = new Point(18, 40);
+            Flow6_Type_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_Type_Label.Name = "Flow6_Type_Label";
+            Flow6_Type_Label.Size = new Size(28, 15);
+            Flow6_Type_Label.TabIndex = 21;
+            Flow6_Type_Label.Text = "Тип";
             // 
             // Flow6_Modification_CB
             //
@@ -1204,15 +1204,15 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Modification_CB.DropDownClosed += RestoreComboText;
             Flow6_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             // 
-            // label47
+            // Flow6_Modification_Label
             // 
-            label47.AutoSize = true;
-            label47.Location = new Point(18, 130);
-            label47.Margin = new Padding(4, 0, 4, 0);
-            label47.Name = "label47";
-            label47.Size = new Size(86, 15);
-            label47.TabIndex = 25;
-            label47.Text = "Модификация";
+            Flow6_Modification_Label.AutoSize = true;
+            Flow6_Modification_Label.Location = new Point(18, 130);
+            Flow6_Modification_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_Modification_Label.Name = "Flow6_Modification_Label";
+            Flow6_Modification_Label.Size = new Size(86, 15);
+            Flow6_Modification_Label.TabIndex = 25;
+            Flow6_Modification_Label.Text = "Модификация";
             // 
             // Flow6_ZavodskNomer_TB
             //
@@ -1231,25 +1231,25 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_RegistrationNumber_TB.Size = new Size(155, 23);
             Flow6_RegistrationNumber_TB.TabIndex = 27;
             //
-            // Flow6_RegistrationNumber_L
+            // Flow6_RegistrationNumber_Label
             //
-            Flow6_RegistrationNumber_L.AutoSize = true;
-            Flow6_RegistrationNumber_L.Location = new Point(18, 160);
-            Flow6_RegistrationNumber_L.Margin = new Padding(4, 0, 4, 0);
-            Flow6_RegistrationNumber_L.Name = "Flow6_RegistrationNumber_L";
-            Flow6_RegistrationNumber_L.Size = new Size(134, 15);
-            Flow6_RegistrationNumber_L.TabIndex = 26;
-            Flow6_RegistrationNumber_L.Text = "Номер госреестра СИ";
+            Flow6_RegistrationNumber_Label.AutoSize = true;
+            Flow6_RegistrationNumber_Label.Location = new Point(18, 160);
+            Flow6_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_RegistrationNumber_Label.Name = "Flow6_RegistrationNumber_Label";
+            Flow6_RegistrationNumber_Label.Size = new Size(134, 15);
+            Flow6_RegistrationNumber_Label.TabIndex = 26;
+            Flow6_RegistrationNumber_Label.Text = "Номер госреестра СИ";
             //
-            // label48
+            // Flow6_ZavodskNomer_Label
             //
-            label48.AutoSize = true;
-            label48.Location = new Point(18, 190);
-            label48.Margin = new Padding(4, 0, 4, 0);
-            label48.Name = "label48";
-            label48.Size = new Size(104, 15);
-            label48.TabIndex = 29;
-            label48.Text = "Заводской номер";
+            Flow6_ZavodskNomer_Label.AutoSize = true;
+            Flow6_ZavodskNomer_Label.Location = new Point(18, 190);
+            Flow6_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
+            Flow6_ZavodskNomer_Label.Name = "Flow6_ZavodskNomer_Label";
+            Flow6_ZavodskNomer_Label.Size = new Size(104, 15);
+            Flow6_ZavodskNomer_Label.TabIndex = 29;
+            Flow6_ZavodskNomer_Label.Text = "Заводской номер";
             // 
             // Next_B
             // 
@@ -1278,30 +1278,30 @@ namespace PoverkaWinForms.Forms.Verifier
             ClientSize = new Size(1158, 728);
             Controls.Add(button1);
             Controls.Add(Next_B);
-            Controls.Add(Rashodomer6_GB);
-            Controls.Add(Rashodomer5_GB);
-            Controls.Add(Rashodomer4_GB);
-            Controls.Add(Rashodomer3_GB);
-            Controls.Add(Rashodomer2_GB);
-            Controls.Add(Rashodomer1_GB);
+            Controls.Add(Flow6_GB);
+            Controls.Add(Flow5_GB);
+            Controls.Add(Flow4_GB);
+            Controls.Add(Flow3_GB);
+            Controls.Add(Flow2_GB);
+            Controls.Add(Flow1_GB);
             Controls.Add(label1);
             Margin = new Padding(4);
             Name = "MetersSetupForm";
             StartPosition = FormStartPosition.CenterScreen;
             Text = "Настройка параметров поверяемых преобразователей";
             Load += MetersSetupForm_Load;
-            Rashodomer1_GB.ResumeLayout(false);
-            Rashodomer1_GB.PerformLayout();
-            Rashodomer2_GB.ResumeLayout(false);
-            Rashodomer2_GB.PerformLayout();
-            Rashodomer3_GB.ResumeLayout(false);
-            Rashodomer3_GB.PerformLayout();
-            Rashodomer4_GB.ResumeLayout(false);
-            Rashodomer4_GB.PerformLayout();
-            Rashodomer5_GB.ResumeLayout(false);
-            Rashodomer5_GB.PerformLayout();
-            Rashodomer6_GB.ResumeLayout(false);
-            Rashodomer6_GB.PerformLayout();
+            Flow1_GB.ResumeLayout(false);
+            Flow1_GB.PerformLayout();
+            Flow2_GB.ResumeLayout(false);
+            Flow2_GB.PerformLayout();
+            Flow3_GB.ResumeLayout(false);
+            Flow3_GB.PerformLayout();
+            Flow4_GB.ResumeLayout(false);
+            Flow4_GB.PerformLayout();
+            Flow5_GB.ResumeLayout(false);
+            Flow5_GB.PerformLayout();
+            Flow6_GB.ResumeLayout(false);
+            Flow6_GB.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -1310,97 +1310,97 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.Windows.Forms.TextBox Flow1_ZavodskNomer_TB;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label Flow1_ZavodskNomer_Label;
+        private System.Windows.Forms.Label Flow1_Modification_Label;
         private System.Windows.Forms.ComboBox Flow1_Modification_CB;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label Flow1_Type_Label;
         private System.Windows.Forms.ComboBox Flow1_Type_CB;
-        private System.Windows.Forms.Label Flow1_Manufacturer_L;
+        private System.Windows.Forms.Label Flow1_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow1_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow1_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow1_ManufactureDate_L;
+        private System.Windows.Forms.Label Flow1_ManufactureDate_Label;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.GroupBox Rashodomer1_GB;
-        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.GroupBox Flow1_GB;
+        private System.Windows.Forms.Label Flow1_Title_Label;
         private System.Windows.Forms.TextBox Flow1_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow1_RegistrationNumber_L;
-        private System.Windows.Forms.GroupBox Rashodomer2_GB;
-        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label Flow1_RegistrationNumber_Label;
+        private System.Windows.Forms.GroupBox Flow2_GB;
+        private System.Windows.Forms.Label Flow2_Title_Label;
         private System.Windows.Forms.ComboBox Flow2_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow2_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow2_ManufactureDate_L;
-        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Label Flow2_ManufactureDate_Label;
+        private System.Windows.Forms.Label Flow2_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow2_Type_CB;
-        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label Flow2_Type_Label;
         private System.Windows.Forms.ComboBox Flow2_Modification_CB;
-        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.Label Flow2_Modification_Label;
         private System.Windows.Forms.TextBox Flow2_ZavodskNomer_TB;
         private System.Windows.Forms.TextBox Flow2_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow2_RegistrationNumber_L;
-        private System.Windows.Forms.Label label17;
-        private System.Windows.Forms.GroupBox Rashodomer3_GB;
-        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label Flow2_RegistrationNumber_Label;
+        private System.Windows.Forms.Label Flow2_ZavodskNomer_Label;
+        private System.Windows.Forms.GroupBox Flow3_GB;
+        private System.Windows.Forms.Label Flow3_Title_Label;
         private System.Windows.Forms.ComboBox Flow3_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow3_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow3_ManufactureDate_L;
-        private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.Label Flow3_ManufactureDate_Label;
+        private System.Windows.Forms.Label Flow3_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow3_Type_CB;
-        private System.Windows.Forms.Label label21;
+        private System.Windows.Forms.Label Flow3_Type_Label;
         private System.Windows.Forms.ComboBox Flow3_Modification_CB;
-        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.Label Flow3_Modification_Label;
         private System.Windows.Forms.TextBox Flow3_ZavodskNomer_TB;
         private System.Windows.Forms.TextBox Flow3_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow3_RegistrationNumber_L;
-        private System.Windows.Forms.Label label24;
-        private System.Windows.Forms.GroupBox Rashodomer4_GB;
-        private System.Windows.Forms.Label label25;
+        private System.Windows.Forms.Label Flow3_RegistrationNumber_Label;
+        private System.Windows.Forms.Label Flow3_ZavodskNomer_Label;
+        private System.Windows.Forms.GroupBox Flow4_GB;
+        private System.Windows.Forms.Label Flow4_Title_Label;
         private System.Windows.Forms.ComboBox Flow4_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow4_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow4_ManufactureDate_L;
-        private System.Windows.Forms.Label label27;
+        private System.Windows.Forms.Label Flow4_ManufactureDate_Label;
+        private System.Windows.Forms.Label Flow4_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow4_Type_CB;
-        private System.Windows.Forms.Label label29;
+        private System.Windows.Forms.Label Flow4_Type_Label;
         private System.Windows.Forms.ComboBox Flow4_Modification_CB;
-        private System.Windows.Forms.Label label31;
+        private System.Windows.Forms.Label Flow4_Modification_Label;
         private System.Windows.Forms.TextBox Flow4_ZavodskNomer_TB;
         private System.Windows.Forms.TextBox Flow4_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow4_RegistrationNumber_L;
-        private System.Windows.Forms.Label label32;
-        private System.Windows.Forms.GroupBox Rashodomer5_GB;
-        private System.Windows.Forms.Label label33;
+        private System.Windows.Forms.Label Flow4_RegistrationNumber_Label;
+        private System.Windows.Forms.Label Flow4_ZavodskNomer_Label;
+        private System.Windows.Forms.GroupBox Flow5_GB;
+        private System.Windows.Forms.Label Flow5_Title_Label;
         private System.Windows.Forms.ComboBox Flow5_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow5_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow5_ManufactureDate_L;
-        private System.Windows.Forms.Label label35;
+        private System.Windows.Forms.Label Flow5_ManufactureDate_Label;
+        private System.Windows.Forms.Label Flow5_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow5_Type_CB;
-        private System.Windows.Forms.Label label37;
+        private System.Windows.Forms.Label Flow5_Type_Label;
         private System.Windows.Forms.ComboBox Flow5_Modification_CB;
-        private System.Windows.Forms.Label label39;
+        private System.Windows.Forms.Label Flow5_Modification_Label;
         private System.Windows.Forms.TextBox Flow5_ZavodskNomer_TB;
         private System.Windows.Forms.TextBox Flow5_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow5_RegistrationNumber_L;
-        private System.Windows.Forms.Label label40;
-        private System.Windows.Forms.GroupBox Rashodomer6_GB;
-        private System.Windows.Forms.Label label41;
+        private System.Windows.Forms.Label Flow5_RegistrationNumber_Label;
+        private System.Windows.Forms.Label Flow5_ZavodskNomer_Label;
+        private System.Windows.Forms.GroupBox Flow6_GB;
+        private System.Windows.Forms.Label Flow6_Title_Label;
         private System.Windows.Forms.ComboBox Flow6_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow6_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow6_ManufactureDate_L;
-        private System.Windows.Forms.Label label43;
+        private System.Windows.Forms.Label Flow6_ManufactureDate_Label;
+        private System.Windows.Forms.Label Flow6_Manufacturer_Label;
         private System.Windows.Forms.ComboBox Flow6_Type_CB;
-        private System.Windows.Forms.Label label45;
+        private System.Windows.Forms.Label Flow6_Type_Label;
         private System.Windows.Forms.ComboBox Flow6_Modification_CB;
-        private System.Windows.Forms.Label label47;
+        private System.Windows.Forms.Label Flow6_Modification_Label;
         private System.Windows.Forms.TextBox Flow6_ZavodskNomer_TB;
         private System.Windows.Forms.TextBox Flow6_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow6_RegistrationNumber_L;
-        private System.Windows.Forms.Label label48;
+        private System.Windows.Forms.Label Flow6_RegistrationNumber_Label;
+        private System.Windows.Forms.Label Flow6_ZavodskNomer_Label;
         private System.Windows.Forms.Button Next_B;
         private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.CheckBox Rashodomer1_CB;
-        private System.Windows.Forms.CheckBox Rashodomer2_CB;
-        private System.Windows.Forms.CheckBox Rashodomer3_CB;
-        private System.Windows.Forms.CheckBox Rashodomer6_CB;
-        private System.Windows.Forms.CheckBox Rashodomer5_CB;
-        private System.Windows.Forms.CheckBox Rashodomer4_CB;
+        private System.Windows.Forms.CheckBox Flow1_CB;
+        private System.Windows.Forms.CheckBox Flow2_CB;
+        private System.Windows.Forms.CheckBox Flow3_CB;
+        private System.Windows.Forms.CheckBox Flow6_CB;
+        private System.Windows.Forms.CheckBox Flow5_CB;
+        private System.Windows.Forms.CheckBox Flow4_CB;
     }
 }

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -213,7 +213,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Name_SI_CB.SelectedIndexChanged += Flow1_Name_SI_CB_SelectedIndexChanged;
             Flow1_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow1_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow1_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow1_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // GosReestr
@@ -436,7 +436,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Name_SI_CB.SelectedIndexChanged += Flow2_Name_SI_CB_SelectedIndexChanged;
             Flow2_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow2_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow2_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow2_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label14
@@ -622,7 +622,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Name_SI_CB.SelectedIndexChanged += Flow3_Name_SI_CB_SelectedIndexChanged;
             Flow3_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow3_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow3_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow3_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label21
@@ -807,7 +807,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Name_SI_CB.SelectedIndexChanged += Flow4_Name_SI_CB_SelectedIndexChanged;
             Flow4_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow4_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow4_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow4_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label29
@@ -992,7 +992,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Name_SI_CB.SelectedIndexChanged += Flow5_Name_SI_CB_SelectedIndexChanged;
             Flow5_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow5_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow5_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow5_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label37
@@ -1177,7 +1177,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Name_SI_CB.SelectedIndexChanged += Flow6_Name_SI_CB_SelectedIndexChanged;
             Flow6_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow6_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
+            Flow6_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow6_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label45

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -36,9 +36,9 @@ namespace PoverkaWinForms.Forms.Verifier
             label3 = new Label();
             Flow1_Modification_CB = new ComboBox();
             label2 = new Label();
-            Flow1_Name_SI_CB = new ComboBox();
-            GosReestr = new Label();
-            Flow1_GosReestr_CB = new ComboBox();
+            Flow1_Type_CB = new ComboBox();
+            Flow1_Manufacturer_L = new Label();
+            Flow1_Manufacturer_CB = new ComboBox();
             Flow1_ManufactureDate_DTP = new DateTimePicker();
             Flow1_ManufactureDate_L = new Label();
             label1 = new Label();
@@ -48,11 +48,11 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer2_GB = new GroupBox();
             label10 = new Label();
             Rashodomer2_CB = new CheckBox();
-            Flow2_GosReestr_CB = new ComboBox();
+            Flow2_Manufacturer_CB = new ComboBox();
             Flow2_ManufactureDate_DTP = new DateTimePicker();
             Flow2_ManufactureDate_L = new Label();
             label12 = new Label();
-            Flow2_Name_SI_CB = new ComboBox();
+            Flow2_Type_CB = new ComboBox();
             label14 = new Label();
             Flow2_Modification_CB = new ComboBox();
             label16 = new Label();
@@ -63,11 +63,11 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer3_GB = new GroupBox();
             label9 = new Label();
             Rashodomer3_CB = new CheckBox();
-            Flow3_GosReestr_CB = new ComboBox();
+            Flow3_Manufacturer_CB = new ComboBox();
             Flow3_ManufactureDate_DTP = new DateTimePicker();
             Flow3_ManufactureDate_L = new Label();
             label19 = new Label();
-            Flow3_Name_SI_CB = new ComboBox();
+            Flow3_Type_CB = new ComboBox();
             label21 = new Label();
             Flow3_Modification_CB = new ComboBox();
             label23 = new Label();
@@ -78,11 +78,11 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer4_GB = new GroupBox();
             label25 = new Label();
             Rashodomer4_CB = new CheckBox();
-            Flow4_GosReestr_CB = new ComboBox();
+            Flow4_Manufacturer_CB = new ComboBox();
             Flow4_ManufactureDate_DTP = new DateTimePicker();
             Flow4_ManufactureDate_L = new Label();
             label27 = new Label();
-            Flow4_Name_SI_CB = new ComboBox();
+            Flow4_Type_CB = new ComboBox();
             label29 = new Label();
             Flow4_Modification_CB = new ComboBox();
             label31 = new Label();
@@ -93,11 +93,11 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer5_GB = new GroupBox();
             label33 = new Label();
             Rashodomer5_CB = new CheckBox();
-            Flow5_GosReestr_CB = new ComboBox();
+            Flow5_Manufacturer_CB = new ComboBox();
             Flow5_ManufactureDate_DTP = new DateTimePicker();
             Flow5_ManufactureDate_L = new Label();
             label35 = new Label();
-            Flow5_Name_SI_CB = new ComboBox();
+            Flow5_Type_CB = new ComboBox();
             label37 = new Label();
             Flow5_Modification_CB = new ComboBox();
             label39 = new Label();
@@ -108,11 +108,11 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer6_GB = new GroupBox();
             label41 = new Label();
             Rashodomer6_CB = new CheckBox();
-            Flow6_GosReestr_CB = new ComboBox();
+            Flow6_Manufacturer_CB = new ComboBox();
             Flow6_ManufactureDate_DTP = new DateTimePicker();
             Flow6_ManufactureDate_L = new Label();
             label43 = new Label();
-            Flow6_Name_SI_CB = new ComboBox();
+            Flow6_Type_CB = new ComboBox();
             label45 = new Label();
             Flow6_Modification_CB = new ComboBox();
             label47 = new Label();
@@ -202,47 +202,47 @@ namespace PoverkaWinForms.Forms.Verifier
             label2.TabIndex = 21;
             label2.Text = "Тип";
             // 
-            // Flow1_Name_SI_CB
+            // Flow1_Type_CB
             // 
-            Flow1_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow1_Name_SI_CB.Location = new Point(168, 38);
-            Flow1_Name_SI_CB.Margin = new Padding(4);
-            Flow1_Name_SI_CB.Name = "Flow1_Name_SI_CB";
-            Flow1_Name_SI_CB.Size = new Size(155, 23);
-            Flow1_Name_SI_CB.TabIndex = 20;
-            Flow1_Name_SI_CB.SelectedIndexChanged += Flow1_Name_SI_CB_SelectedIndexChanged;
-            Flow1_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow1_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow1_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow1_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow1_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1_Type_CB.Location = new Point(168, 38);
+            Flow1_Type_CB.Margin = new Padding(4);
+            Flow1_Type_CB.Name = "Flow1_Type_CB";
+            Flow1_Type_CB.Size = new Size(155, 23);
+            Flow1_Type_CB.TabIndex = 20;
+            Flow1_Type_CB.SelectedIndexChanged += Flow1_Type_CB_SelectedIndexChanged;
+            Flow1_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow1_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow1_Type_CB.Click += MeterTypeCB_Click;
+            Flow1_Type_CB.DropDownClosed += RestoreComboText;
             // 
-            // GosReestr
+            // Flow1_Manufacturer_L
             // 
-            GosReestr.AutoSize = true;
-            GosReestr.Location = new Point(18, 70);
-            GosReestr.Margin = new Padding(4, 0, 4, 0);
-            GosReestr.Name = "GosReestr";
-            GosReestr.Size = new Size(92, 15);
-            GosReestr.TabIndex = 23;
-            GosReestr.Text = "Производитель";
+            Flow1_Manufacturer_L.AutoSize = true;
+            Flow1_Manufacturer_L.Location = new Point(18, 70);
+            Flow1_Manufacturer_L.Margin = new Padding(4, 0, 4, 0);
+            Flow1_Manufacturer_L.Name = "Flow1_Manufacturer_L";
+            Flow1_Manufacturer_L.Size = new Size(92, 15);
+            Flow1_Manufacturer_L.TabIndex = 23;
+            Flow1_Manufacturer_L.Text = "Производитель";
             // 
-            // Flow1_GosReestr_CB
+            // Flow1_Manufacturer_CB
             // 
-            Flow1_GosReestr_CB.AllowDrop = true;
-            Flow1_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow1_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow1_GosReestr_CB.FormattingEnabled = true;
-            Flow1_GosReestr_CB.IntegralHeight = false;
-            Flow1_GosReestr_CB.Location = new Point(168, 67);
-            Flow1_GosReestr_CB.Margin = new Padding(4);
-            Flow1_GosReestr_CB.Name = "Flow1_GosReestr_CB";
-            Flow1_GosReestr_CB.Size = new Size(155, 23);
-            Flow1_GosReestr_CB.TabIndex = 22;
-            Flow1_GosReestr_CB.SelectedIndexChanged += GosReestrCB_SelectedIndexChanged;
-            Flow1_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow1_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow1_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow1_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow1_Manufacturer_CB.AllowDrop = true;
+            Flow1_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow1_Manufacturer_CB.FormattingEnabled = true;
+            Flow1_Manufacturer_CB.IntegralHeight = false;
+            Flow1_Manufacturer_CB.Location = new Point(168, 67);
+            Flow1_Manufacturer_CB.Margin = new Padding(4);
+            Flow1_Manufacturer_CB.Name = "Flow1_Manufacturer_CB";
+            Flow1_Manufacturer_CB.Size = new Size(155, 23);
+            Flow1_Manufacturer_CB.TabIndex = 22;
+            Flow1_Manufacturer_CB.SelectedIndexChanged += Flow1_Manufacturer_CB_SelectedIndexChanged;
+            Flow1_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow1_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow1_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow1_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow1_ManufactureDate_DTP
             //
@@ -281,11 +281,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer1_GB.Controls.Add(label8);
             Rashodomer1_GB.Controls.Add(Rashodomer1_CB);
-            Rashodomer1_GB.Controls.Add(Flow1_GosReestr_CB);
+            Rashodomer1_GB.Controls.Add(Flow1_Manufacturer_CB);
             Rashodomer1_GB.Controls.Add(Flow1_ManufactureDate_DTP);
             Rashodomer1_GB.Controls.Add(Flow1_ManufactureDate_L);
-            Rashodomer1_GB.Controls.Add(GosReestr);
-            Rashodomer1_GB.Controls.Add(Flow1_Name_SI_CB);
+            Rashodomer1_GB.Controls.Add(Flow1_Manufacturer_L);
+            Rashodomer1_GB.Controls.Add(Flow1_Type_CB);
             Rashodomer1_GB.Controls.Add(label2);
             Rashodomer1_GB.Controls.Add(Flow1_Modification_CB);
             Rashodomer1_GB.Controls.Add(label3);
@@ -330,11 +330,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer2_GB.Controls.Add(label10);
             Rashodomer2_GB.Controls.Add(Rashodomer2_CB);
-            Rashodomer2_GB.Controls.Add(Flow2_GosReestr_CB);
+            Rashodomer2_GB.Controls.Add(Flow2_Manufacturer_CB);
             Rashodomer2_GB.Controls.Add(Flow2_ManufactureDate_DTP);
             Rashodomer2_GB.Controls.Add(Flow2_ManufactureDate_L);
             Rashodomer2_GB.Controls.Add(label12);
-            Rashodomer2_GB.Controls.Add(Flow2_Name_SI_CB);
+            Rashodomer2_GB.Controls.Add(Flow2_Type_CB);
             Rashodomer2_GB.Controls.Add(label14);
             Rashodomer2_GB.Controls.Add(Flow2_Modification_CB);
             Rashodomer2_GB.Controls.Add(label16);
@@ -375,23 +375,23 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer2_CB.UseVisualStyleBackColor = true;
             Rashodomer2_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
-            // Flow2_GosReestr_CB
+            // Flow2_Manufacturer_CB
             //
-            Flow2_GosReestr_CB.AllowDrop = true;
-            Flow2_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow2_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow2_GosReestr_CB.FormattingEnabled = true;
-            Flow2_GosReestr_CB.IntegralHeight = false;
-            Flow2_GosReestr_CB.Location = new Point(168, 67);
-            Flow2_GosReestr_CB.Margin = new Padding(4);
-            Flow2_GosReestr_CB.Name = "Flow2_GosReestr_CB";
-            Flow2_GosReestr_CB.Size = new Size(155, 23);
-            Flow2_GosReestr_CB.TabIndex = 22;
-            Flow2_GosReestr_CB.SelectedIndexChanged += Flow2_GosReestr_CB_SelectedIndexChanged;
-            Flow2_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow2_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow2_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow2_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow2_Manufacturer_CB.AllowDrop = true;
+            Flow2_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow2_Manufacturer_CB.FormattingEnabled = true;
+            Flow2_Manufacturer_CB.IntegralHeight = false;
+            Flow2_Manufacturer_CB.Location = new Point(168, 67);
+            Flow2_Manufacturer_CB.Margin = new Padding(4);
+            Flow2_Manufacturer_CB.Name = "Flow2_Manufacturer_CB";
+            Flow2_Manufacturer_CB.Size = new Size(155, 23);
+            Flow2_Manufacturer_CB.TabIndex = 22;
+            Flow2_Manufacturer_CB.SelectedIndexChanged += Flow2_Manufacturer_CB_SelectedIndexChanged;
+            Flow2_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow2_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow2_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow2_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow2_ManufactureDate_DTP
             //
@@ -425,19 +425,19 @@ namespace PoverkaWinForms.Forms.Verifier
             label12.TabIndex = 23;
             label12.Text = "Производитель";
             // 
-            // Flow2_Name_SI_CB
+            // Flow2_Type_CB
             //
-            Flow2_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow2_Name_SI_CB.Location = new Point(168, 38);
-            Flow2_Name_SI_CB.Margin = new Padding(4);
-            Flow2_Name_SI_CB.Name = "Flow2_Name_SI_CB";
-            Flow2_Name_SI_CB.Size = new Size(155, 23);
-            Flow2_Name_SI_CB.TabIndex = 20;
-            Flow2_Name_SI_CB.SelectedIndexChanged += Flow2_Name_SI_CB_SelectedIndexChanged;
-            Flow2_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow2_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow2_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow2_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow2_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2_Type_CB.Location = new Point(168, 38);
+            Flow2_Type_CB.Margin = new Padding(4);
+            Flow2_Type_CB.Name = "Flow2_Type_CB";
+            Flow2_Type_CB.Size = new Size(155, 23);
+            Flow2_Type_CB.TabIndex = 20;
+            Flow2_Type_CB.SelectedIndexChanged += Flow2_Type_CB_SelectedIndexChanged;
+            Flow2_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow2_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow2_Type_CB.Click += MeterTypeCB_Click;
+            Flow2_Type_CB.DropDownClosed += RestoreComboText;
             // 
             // label14
             //
@@ -515,11 +515,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer3_GB.Controls.Add(label9);
             Rashodomer3_GB.Controls.Add(Rashodomer3_CB);
-            Rashodomer3_GB.Controls.Add(Flow3_GosReestr_CB);
+            Rashodomer3_GB.Controls.Add(Flow3_Manufacturer_CB);
             Rashodomer3_GB.Controls.Add(Flow3_ManufactureDate_DTP);
             Rashodomer3_GB.Controls.Add(Flow3_ManufactureDate_L);
             Rashodomer3_GB.Controls.Add(label19);
-            Rashodomer3_GB.Controls.Add(Flow3_Name_SI_CB);
+            Rashodomer3_GB.Controls.Add(Flow3_Type_CB);
             Rashodomer3_GB.Controls.Add(label21);
             Rashodomer3_GB.Controls.Add(Flow3_Modification_CB);
             Rashodomer3_GB.Controls.Add(label23);
@@ -560,23 +560,23 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer3_CB.UseVisualStyleBackColor = true;
             Rashodomer3_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
-            // Flow3_GosReestr_CB
+            // Flow3_Manufacturer_CB
             //
-            Flow3_GosReestr_CB.AllowDrop = true;
-            Flow3_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow3_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow3_GosReestr_CB.FormattingEnabled = true;
-            Flow3_GosReestr_CB.IntegralHeight = false;
-            Flow3_GosReestr_CB.Location = new Point(168, 67);
-            Flow3_GosReestr_CB.Margin = new Padding(4);
-            Flow3_GosReestr_CB.Name = "Flow3_GosReestr_CB";
-            Flow3_GosReestr_CB.Size = new Size(155, 23);
-            Flow3_GosReestr_CB.TabIndex = 22;
-            Flow3_GosReestr_CB.SelectedIndexChanged += Flow3_GosReestr_CB_SelectedIndexChanged;
-            Flow3_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow3_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow3_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow3_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow3_Manufacturer_CB.AllowDrop = true;
+            Flow3_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow3_Manufacturer_CB.FormattingEnabled = true;
+            Flow3_Manufacturer_CB.IntegralHeight = false;
+            Flow3_Manufacturer_CB.Location = new Point(168, 67);
+            Flow3_Manufacturer_CB.Margin = new Padding(4);
+            Flow3_Manufacturer_CB.Name = "Flow3_Manufacturer_CB";
+            Flow3_Manufacturer_CB.Size = new Size(155, 23);
+            Flow3_Manufacturer_CB.TabIndex = 22;
+            Flow3_Manufacturer_CB.SelectedIndexChanged += Flow3_Manufacturer_CB_SelectedIndexChanged;
+            Flow3_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow3_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow3_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow3_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow3_ManufactureDate_DTP
             //
@@ -610,19 +610,19 @@ namespace PoverkaWinForms.Forms.Verifier
             label19.TabIndex = 23;
             label19.Text = "Производитель";
             // 
-            // Flow3_Name_SI_CB
+            // Flow3_Type_CB
             //
-            Flow3_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow3_Name_SI_CB.Location = new Point(168, 38);
-            Flow3_Name_SI_CB.Margin = new Padding(4);
-            Flow3_Name_SI_CB.Name = "Flow3_Name_SI_CB";
-            Flow3_Name_SI_CB.Size = new Size(155, 23);
-            Flow3_Name_SI_CB.TabIndex = 20;
-            Flow3_Name_SI_CB.SelectedIndexChanged += Flow3_Name_SI_CB_SelectedIndexChanged;
-            Flow3_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow3_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow3_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow3_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow3_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3_Type_CB.Location = new Point(168, 38);
+            Flow3_Type_CB.Margin = new Padding(4);
+            Flow3_Type_CB.Name = "Flow3_Type_CB";
+            Flow3_Type_CB.Size = new Size(155, 23);
+            Flow3_Type_CB.TabIndex = 20;
+            Flow3_Type_CB.SelectedIndexChanged += Flow3_Type_CB_SelectedIndexChanged;
+            Flow3_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow3_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow3_Type_CB.Click += MeterTypeCB_Click;
+            Flow3_Type_CB.DropDownClosed += RestoreComboText;
             // 
             // label21
             //
@@ -700,11 +700,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer4_GB.Controls.Add(label25);
             Rashodomer4_GB.Controls.Add(Rashodomer4_CB);
-            Rashodomer4_GB.Controls.Add(Flow4_GosReestr_CB);
+            Rashodomer4_GB.Controls.Add(Flow4_Manufacturer_CB);
             Rashodomer4_GB.Controls.Add(Flow4_ManufactureDate_DTP);
             Rashodomer4_GB.Controls.Add(Flow4_ManufactureDate_L);
             Rashodomer4_GB.Controls.Add(label27);
-            Rashodomer4_GB.Controls.Add(Flow4_Name_SI_CB);
+            Rashodomer4_GB.Controls.Add(Flow4_Type_CB);
             Rashodomer4_GB.Controls.Add(label29);
             Rashodomer4_GB.Controls.Add(Flow4_Modification_CB);
             Rashodomer4_GB.Controls.Add(label31);
@@ -745,23 +745,23 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer4_CB.UseVisualStyleBackColor = true;
             Rashodomer4_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
-            // Flow4_GosReestr_CB
+            // Flow4_Manufacturer_CB
             //
-            Flow4_GosReestr_CB.AllowDrop = true;
-            Flow4_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow4_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow4_GosReestr_CB.FormattingEnabled = true;
-            Flow4_GosReestr_CB.IntegralHeight = false;
-            Flow4_GosReestr_CB.Location = new Point(168, 67);
-            Flow4_GosReestr_CB.Margin = new Padding(4);
-            Flow4_GosReestr_CB.Name = "Flow4_GosReestr_CB";
-            Flow4_GosReestr_CB.Size = new Size(155, 23);
-            Flow4_GosReestr_CB.TabIndex = 22;
-            Flow4_GosReestr_CB.SelectedIndexChanged += Flow4_GosReestr_CB_SelectedIndexChanged;
-            Flow4_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow4_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow4_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow4_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow4_Manufacturer_CB.AllowDrop = true;
+            Flow4_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow4_Manufacturer_CB.FormattingEnabled = true;
+            Flow4_Manufacturer_CB.IntegralHeight = false;
+            Flow4_Manufacturer_CB.Location = new Point(168, 67);
+            Flow4_Manufacturer_CB.Margin = new Padding(4);
+            Flow4_Manufacturer_CB.Name = "Flow4_Manufacturer_CB";
+            Flow4_Manufacturer_CB.Size = new Size(155, 23);
+            Flow4_Manufacturer_CB.TabIndex = 22;
+            Flow4_Manufacturer_CB.SelectedIndexChanged += Flow4_Manufacturer_CB_SelectedIndexChanged;
+            Flow4_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow4_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow4_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow4_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow4_ManufactureDate_DTP
             //
@@ -795,19 +795,19 @@ namespace PoverkaWinForms.Forms.Verifier
             label27.TabIndex = 23;
             label27.Text = "Производитель";
             // 
-            // Flow4_Name_SI_CB
+            // Flow4_Type_CB
             //
-            Flow4_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow4_Name_SI_CB.Location = new Point(168, 38);
-            Flow4_Name_SI_CB.Margin = new Padding(4);
-            Flow4_Name_SI_CB.Name = "Flow4_Name_SI_CB";
-            Flow4_Name_SI_CB.Size = new Size(155, 23);
-            Flow4_Name_SI_CB.TabIndex = 20;
-            Flow4_Name_SI_CB.SelectedIndexChanged += Flow4_Name_SI_CB_SelectedIndexChanged;
-            Flow4_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow4_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow4_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow4_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow4_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4_Type_CB.Location = new Point(168, 38);
+            Flow4_Type_CB.Margin = new Padding(4);
+            Flow4_Type_CB.Name = "Flow4_Type_CB";
+            Flow4_Type_CB.Size = new Size(155, 23);
+            Flow4_Type_CB.TabIndex = 20;
+            Flow4_Type_CB.SelectedIndexChanged += Flow4_Type_CB_SelectedIndexChanged;
+            Flow4_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow4_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow4_Type_CB.Click += MeterTypeCB_Click;
+            Flow4_Type_CB.DropDownClosed += RestoreComboText;
             // 
             // label29
             //
@@ -885,11 +885,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer5_GB.Controls.Add(label33);
             Rashodomer5_GB.Controls.Add(Rashodomer5_CB);
-            Rashodomer5_GB.Controls.Add(Flow5_GosReestr_CB);
+            Rashodomer5_GB.Controls.Add(Flow5_Manufacturer_CB);
             Rashodomer5_GB.Controls.Add(Flow5_ManufactureDate_DTP);
             Rashodomer5_GB.Controls.Add(Flow5_ManufactureDate_L);
             Rashodomer5_GB.Controls.Add(label35);
-            Rashodomer5_GB.Controls.Add(Flow5_Name_SI_CB);
+            Rashodomer5_GB.Controls.Add(Flow5_Type_CB);
             Rashodomer5_GB.Controls.Add(label37);
             Rashodomer5_GB.Controls.Add(Flow5_Modification_CB);
             Rashodomer5_GB.Controls.Add(label39);
@@ -930,23 +930,23 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer5_CB.UseVisualStyleBackColor = true;
             Rashodomer5_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
-            // Flow5_GosReestr_CB
+            // Flow5_Manufacturer_CB
             //
-            Flow5_GosReestr_CB.AllowDrop = true;
-            Flow5_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow5_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow5_GosReestr_CB.FormattingEnabled = true;
-            Flow5_GosReestr_CB.IntegralHeight = false;
-            Flow5_GosReestr_CB.Location = new Point(168, 67);
-            Flow5_GosReestr_CB.Margin = new Padding(4);
-            Flow5_GosReestr_CB.Name = "Flow5_GosReestr_CB";
-            Flow5_GosReestr_CB.Size = new Size(155, 23);
-            Flow5_GosReestr_CB.TabIndex = 22;
-            Flow5_GosReestr_CB.SelectedIndexChanged += Flow5_GosReestr_CB_SelectedIndexChanged;
-            Flow5_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow5_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow5_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow5_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow5_Manufacturer_CB.AllowDrop = true;
+            Flow5_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow5_Manufacturer_CB.FormattingEnabled = true;
+            Flow5_Manufacturer_CB.IntegralHeight = false;
+            Flow5_Manufacturer_CB.Location = new Point(168, 67);
+            Flow5_Manufacturer_CB.Margin = new Padding(4);
+            Flow5_Manufacturer_CB.Name = "Flow5_Manufacturer_CB";
+            Flow5_Manufacturer_CB.Size = new Size(155, 23);
+            Flow5_Manufacturer_CB.TabIndex = 22;
+            Flow5_Manufacturer_CB.SelectedIndexChanged += Flow5_Manufacturer_CB_SelectedIndexChanged;
+            Flow5_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow5_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow5_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow5_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow5_ManufactureDate_DTP
             //
@@ -980,19 +980,19 @@ namespace PoverkaWinForms.Forms.Verifier
             label35.TabIndex = 23;
             label35.Text = "Производитель";
             // 
-            // Flow5_Name_SI_CB
+            // Flow5_Type_CB
             //
-            Flow5_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow5_Name_SI_CB.Location = new Point(168, 38);
-            Flow5_Name_SI_CB.Margin = new Padding(4);
-            Flow5_Name_SI_CB.Name = "Flow5_Name_SI_CB";
-            Flow5_Name_SI_CB.Size = new Size(155, 23);
-            Flow5_Name_SI_CB.TabIndex = 20;
-            Flow5_Name_SI_CB.SelectedIndexChanged += Flow5_Name_SI_CB_SelectedIndexChanged;
-            Flow5_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow5_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow5_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow5_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow5_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5_Type_CB.Location = new Point(168, 38);
+            Flow5_Type_CB.Margin = new Padding(4);
+            Flow5_Type_CB.Name = "Flow5_Type_CB";
+            Flow5_Type_CB.Size = new Size(155, 23);
+            Flow5_Type_CB.TabIndex = 20;
+            Flow5_Type_CB.SelectedIndexChanged += Flow5_Type_CB_SelectedIndexChanged;
+            Flow5_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow5_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow5_Type_CB.Click += MeterTypeCB_Click;
+            Flow5_Type_CB.DropDownClosed += RestoreComboText;
             // 
             // label37
             //
@@ -1070,11 +1070,11 @@ namespace PoverkaWinForms.Forms.Verifier
             // 
             Rashodomer6_GB.Controls.Add(label41);
             Rashodomer6_GB.Controls.Add(Rashodomer6_CB);
-            Rashodomer6_GB.Controls.Add(Flow6_GosReestr_CB);
+            Rashodomer6_GB.Controls.Add(Flow6_Manufacturer_CB);
             Rashodomer6_GB.Controls.Add(Flow6_ManufactureDate_DTP);
             Rashodomer6_GB.Controls.Add(Flow6_ManufactureDate_L);
             Rashodomer6_GB.Controls.Add(label43);
-            Rashodomer6_GB.Controls.Add(Flow6_Name_SI_CB);
+            Rashodomer6_GB.Controls.Add(Flow6_Type_CB);
             Rashodomer6_GB.Controls.Add(label45);
             Rashodomer6_GB.Controls.Add(Flow6_Modification_CB);
             Rashodomer6_GB.Controls.Add(label47);
@@ -1115,23 +1115,23 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer6_CB.UseVisualStyleBackColor = true;
             Rashodomer6_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
-            // Flow6_GosReestr_CB
+            // Flow6_Manufacturer_CB
             //
-            Flow6_GosReestr_CB.AllowDrop = true;
-            Flow6_GosReestr_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow6_GosReestr_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow6_GosReestr_CB.FormattingEnabled = true;
-            Flow6_GosReestr_CB.IntegralHeight = false;
-            Flow6_GosReestr_CB.Location = new Point(168, 67);
-            Flow6_GosReestr_CB.Margin = new Padding(4);
-            Flow6_GosReestr_CB.Name = "Flow6_GosReestr_CB";
-            Flow6_GosReestr_CB.Size = new Size(155, 23);
-            Flow6_GosReestr_CB.TabIndex = 22;
-            Flow6_GosReestr_CB.SelectedIndexChanged += Flow6_GosReestr_CB_SelectedIndexChanged;
-            Flow6_GosReestr_CB.Click += ManufacturerCB_Click;
-            Flow6_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow6_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow6_GosReestr_CB.DropDownClosed += RestoreComboText;
+            Flow6_Manufacturer_CB.AllowDrop = true;
+            Flow6_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow6_Manufacturer_CB.FormattingEnabled = true;
+            Flow6_Manufacturer_CB.IntegralHeight = false;
+            Flow6_Manufacturer_CB.Location = new Point(168, 67);
+            Flow6_Manufacturer_CB.Margin = new Padding(4);
+            Flow6_Manufacturer_CB.Name = "Flow6_Manufacturer_CB";
+            Flow6_Manufacturer_CB.Size = new Size(155, 23);
+            Flow6_Manufacturer_CB.TabIndex = 22;
+            Flow6_Manufacturer_CB.SelectedIndexChanged += Flow6_Manufacturer_CB_SelectedIndexChanged;
+            Flow6_Manufacturer_CB.Click += ManufacturerCB_Click;
+            Flow6_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow6_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow6_Manufacturer_CB.DropDownClosed += RestoreComboText;
             //
             // Flow6_ManufactureDate_DTP
             //
@@ -1165,19 +1165,19 @@ namespace PoverkaWinForms.Forms.Verifier
             label43.TabIndex = 23;
             label43.Text = "Производитель";
             // 
-            // Flow6_Name_SI_CB
+            // Flow6_Type_CB
             //
-            Flow6_Name_SI_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow6_Name_SI_CB.Location = new Point(168, 38);
-            Flow6_Name_SI_CB.Margin = new Padding(4);
-            Flow6_Name_SI_CB.Name = "Flow6_Name_SI_CB";
-            Flow6_Name_SI_CB.Size = new Size(155, 23);
-            Flow6_Name_SI_CB.TabIndex = 20;
-            Flow6_Name_SI_CB.SelectedIndexChanged += Flow6_Name_SI_CB_SelectedIndexChanged;
-            Flow6_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow6_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow6_Name_SI_CB.Click += MeterTypeCB_Click;
-            Flow6_Name_SI_CB.DropDownClosed += RestoreComboText;
+            Flow6_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6_Type_CB.Location = new Point(168, 38);
+            Flow6_Type_CB.Margin = new Padding(4);
+            Flow6_Type_CB.Name = "Flow6_Type_CB";
+            Flow6_Type_CB.Size = new Size(155, 23);
+            Flow6_Type_CB.TabIndex = 20;
+            Flow6_Type_CB.SelectedIndexChanged += Flow6_Type_CB_SelectedIndexChanged;
+            Flow6_Type_CB.KeyDown += MeterTypeCB_KeyDown;
+            Flow6_Type_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow6_Type_CB.Click += MeterTypeCB_Click;
+            Flow6_Type_CB.DropDownClosed += RestoreComboText;
             // 
             // label45
             //
@@ -1314,9 +1314,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.ComboBox Flow1_Modification_CB;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.ComboBox Flow1_Name_SI_CB;
-        private System.Windows.Forms.Label GosReestr;
-        private System.Windows.Forms.ComboBox Flow1_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow1_Type_CB;
+        private System.Windows.Forms.Label Flow1_Manufacturer_L;
+        private System.Windows.Forms.ComboBox Flow1_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow1_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow1_ManufactureDate_L;
         private System.Windows.Forms.Label label1;
@@ -1326,11 +1326,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label Flow1_RegistrationNumber_L;
         private System.Windows.Forms.GroupBox Rashodomer2_GB;
         private System.Windows.Forms.Label label10;
-        private System.Windows.Forms.ComboBox Flow2_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow2_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow2_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow2_ManufactureDate_L;
         private System.Windows.Forms.Label label12;
-        private System.Windows.Forms.ComboBox Flow2_Name_SI_CB;
+        private System.Windows.Forms.ComboBox Flow2_Type_CB;
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.ComboBox Flow2_Modification_CB;
         private System.Windows.Forms.Label label16;
@@ -1340,11 +1340,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label17;
         private System.Windows.Forms.GroupBox Rashodomer3_GB;
         private System.Windows.Forms.Label label9;
-        private System.Windows.Forms.ComboBox Flow3_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow3_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow3_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow3_ManufactureDate_L;
         private System.Windows.Forms.Label label19;
-        private System.Windows.Forms.ComboBox Flow3_Name_SI_CB;
+        private System.Windows.Forms.ComboBox Flow3_Type_CB;
         private System.Windows.Forms.Label label21;
         private System.Windows.Forms.ComboBox Flow3_Modification_CB;
         private System.Windows.Forms.Label label23;
@@ -1354,11 +1354,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label24;
         private System.Windows.Forms.GroupBox Rashodomer4_GB;
         private System.Windows.Forms.Label label25;
-        private System.Windows.Forms.ComboBox Flow4_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow4_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow4_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow4_ManufactureDate_L;
         private System.Windows.Forms.Label label27;
-        private System.Windows.Forms.ComboBox Flow4_Name_SI_CB;
+        private System.Windows.Forms.ComboBox Flow4_Type_CB;
         private System.Windows.Forms.Label label29;
         private System.Windows.Forms.ComboBox Flow4_Modification_CB;
         private System.Windows.Forms.Label label31;
@@ -1368,11 +1368,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label32;
         private System.Windows.Forms.GroupBox Rashodomer5_GB;
         private System.Windows.Forms.Label label33;
-        private System.Windows.Forms.ComboBox Flow5_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow5_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow5_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow5_ManufactureDate_L;
         private System.Windows.Forms.Label label35;
-        private System.Windows.Forms.ComboBox Flow5_Name_SI_CB;
+        private System.Windows.Forms.ComboBox Flow5_Type_CB;
         private System.Windows.Forms.Label label37;
         private System.Windows.Forms.ComboBox Flow5_Modification_CB;
         private System.Windows.Forms.Label label39;
@@ -1382,11 +1382,11 @@ namespace PoverkaWinForms.Forms.Verifier
         private System.Windows.Forms.Label label40;
         private System.Windows.Forms.GroupBox Rashodomer6_GB;
         private System.Windows.Forms.Label label41;
-        private System.Windows.Forms.ComboBox Flow6_GosReestr_CB;
+        private System.Windows.Forms.ComboBox Flow6_Manufacturer_CB;
         private System.Windows.Forms.DateTimePicker Flow6_ManufactureDate_DTP;
         private System.Windows.Forms.Label Flow6_ManufactureDate_L;
         private System.Windows.Forms.Label label43;
-        private System.Windows.Forms.ComboBox Flow6_Name_SI_CB;
+        private System.Windows.Forms.ComboBox Flow6_Type_CB;
         private System.Windows.Forms.Label label45;
         private System.Windows.Forms.ComboBox Flow6_Modification_CB;
         private System.Windows.Forms.Label label47;

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -448,8 +448,7 @@ namespace PoverkaWinForms.Forms.Verifier
             label14.Size = new Size(28, 15);
             label14.TabIndex = 21;
             label14.Text = "Тип";
-            label14.Click += label14_Click;
-            // 
+            //
             // Flow2_Modification_CB
             //
             Flow2_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
@@ -1261,10 +1260,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Next_B.TabIndex = 42;
             Next_B.Text = "Далее";
             Next_B.UseVisualStyleBackColor = true;
-            Next_B.Click += Next_B_Click;
-            // 
+            //
             // button1
-            // 
+            //
             button1.Location = new Point(60, 682);
             button1.Margin = new Padding(4);
             button1.Name = "button1";
@@ -1272,10 +1270,9 @@ namespace PoverkaWinForms.Forms.Verifier
             button1.TabIndex = 43;
             button1.Text = "Выход";
             button1.UseVisualStyleBackColor = true;
-            button1.Click += button1_Click;
-            // 
+            //
             // MetersSetupForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1158, 728);

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -190,7 +190,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow1_Modification_CB.Click += ModificationCB_Click;
             Flow1_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow1_Modification_CB.SelectedIndexChanged += Flow1_Modification_CB_SelectedIndexChanged;
+            Flow1_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
             // label2
             //
@@ -210,7 +210,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Type_CB.Name = "Flow1_Type_CB";
             Flow1_Type_CB.Size = new Size(155, 23);
             Flow1_Type_CB.TabIndex = 20;
-            Flow1_Type_CB.SelectedIndexChanged += Flow1_Type_CB_SelectedIndexChanged;
+            Flow1_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow1_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow1_Type_CB.Click += MeterTypeCB_Click;
@@ -238,7 +238,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Manufacturer_CB.Name = "Flow1_Manufacturer_CB";
             Flow1_Manufacturer_CB.Size = new Size(155, 23);
             Flow1_Manufacturer_CB.TabIndex = 22;
-            Flow1_Manufacturer_CB.SelectedIndexChanged += Flow1_Manufacturer_CB_SelectedIndexChanged;
+            Flow1_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow1_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow1_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -254,7 +254,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow1_ManufactureDate_DTP.TabIndex = 24;
             Flow1_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow1_ManufactureDate_DTP.ValueChanged += Flow1_ManufactureDate_DTP_ValueChanged;
+            Flow1_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow1_ManufactureDate_L
             //
@@ -387,7 +387,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Manufacturer_CB.Name = "Flow2_Manufacturer_CB";
             Flow2_Manufacturer_CB.Size = new Size(155, 23);
             Flow2_Manufacturer_CB.TabIndex = 22;
-            Flow2_Manufacturer_CB.SelectedIndexChanged += Flow2_Manufacturer_CB_SelectedIndexChanged;
+            Flow2_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow2_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow2_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -403,7 +403,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow2_ManufactureDate_DTP.TabIndex = 24;
             Flow2_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow2_ManufactureDate_DTP.ValueChanged += Flow2_ManufactureDate_DTP_ValueChanged;
+            Flow2_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow2_ManufactureDate_L
             //
@@ -433,7 +433,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Type_CB.Name = "Flow2_Type_CB";
             Flow2_Type_CB.Size = new Size(155, 23);
             Flow2_Type_CB.TabIndex = 20;
-            Flow2_Type_CB.SelectedIndexChanged += Flow2_Type_CB_SelectedIndexChanged;
+            Flow2_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow2_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow2_Type_CB.Click += MeterTypeCB_Click;
@@ -462,7 +462,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow2_Modification_CB.Click += ModificationCB_Click;
             Flow2_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow2_Modification_CB.SelectedIndexChanged += Flow2_Modification_CB_SelectedIndexChanged;
+            Flow2_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
             // label16
             // 
@@ -572,7 +572,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Manufacturer_CB.Name = "Flow3_Manufacturer_CB";
             Flow3_Manufacturer_CB.Size = new Size(155, 23);
             Flow3_Manufacturer_CB.TabIndex = 22;
-            Flow3_Manufacturer_CB.SelectedIndexChanged += Flow3_Manufacturer_CB_SelectedIndexChanged;
+            Flow3_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow3_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow3_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -588,7 +588,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow3_ManufactureDate_DTP.TabIndex = 24;
             Flow3_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow3_ManufactureDate_DTP.ValueChanged += Flow3_ManufactureDate_DTP_ValueChanged;
+            Flow3_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow3_ManufactureDate_L
             //
@@ -618,7 +618,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Type_CB.Name = "Flow3_Type_CB";
             Flow3_Type_CB.Size = new Size(155, 23);
             Flow3_Type_CB.TabIndex = 20;
-            Flow3_Type_CB.SelectedIndexChanged += Flow3_Type_CB_SelectedIndexChanged;
+            Flow3_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow3_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow3_Type_CB.Click += MeterTypeCB_Click;
@@ -647,7 +647,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow3_Modification_CB.Click += ModificationCB_Click;
             Flow3_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow3_Modification_CB.SelectedIndexChanged += Flow3_Modification_CB_SelectedIndexChanged;
+            Flow3_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
             // label23
             // 
@@ -757,7 +757,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Manufacturer_CB.Name = "Flow4_Manufacturer_CB";
             Flow4_Manufacturer_CB.Size = new Size(155, 23);
             Flow4_Manufacturer_CB.TabIndex = 22;
-            Flow4_Manufacturer_CB.SelectedIndexChanged += Flow4_Manufacturer_CB_SelectedIndexChanged;
+            Flow4_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow4_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow4_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -773,7 +773,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow4_ManufactureDate_DTP.TabIndex = 24;
             Flow4_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow4_ManufactureDate_DTP.ValueChanged += Flow4_ManufactureDate_DTP_ValueChanged;
+            Flow4_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow4_ManufactureDate_L
             //
@@ -803,7 +803,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Type_CB.Name = "Flow4_Type_CB";
             Flow4_Type_CB.Size = new Size(155, 23);
             Flow4_Type_CB.TabIndex = 20;
-            Flow4_Type_CB.SelectedIndexChanged += Flow4_Type_CB_SelectedIndexChanged;
+            Flow4_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow4_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow4_Type_CB.Click += MeterTypeCB_Click;
@@ -832,7 +832,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow4_Modification_CB.Click += ModificationCB_Click;
             Flow4_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow4_Modification_CB.SelectedIndexChanged += Flow4_Modification_CB_SelectedIndexChanged;
+            Flow4_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
             // label31
             // 
@@ -942,7 +942,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Manufacturer_CB.Name = "Flow5_Manufacturer_CB";
             Flow5_Manufacturer_CB.Size = new Size(155, 23);
             Flow5_Manufacturer_CB.TabIndex = 22;
-            Flow5_Manufacturer_CB.SelectedIndexChanged += Flow5_Manufacturer_CB_SelectedIndexChanged;
+            Flow5_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow5_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow5_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -958,7 +958,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow5_ManufactureDate_DTP.TabIndex = 24;
             Flow5_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow5_ManufactureDate_DTP.ValueChanged += Flow5_ManufactureDate_DTP_ValueChanged;
+            Flow5_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow5_ManufactureDate_L
             //
@@ -988,7 +988,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Type_CB.Name = "Flow5_Type_CB";
             Flow5_Type_CB.Size = new Size(155, 23);
             Flow5_Type_CB.TabIndex = 20;
-            Flow5_Type_CB.SelectedIndexChanged += Flow5_Type_CB_SelectedIndexChanged;
+            Flow5_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow5_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow5_Type_CB.Click += MeterTypeCB_Click;
@@ -1017,7 +1017,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow5_Modification_CB.Click += ModificationCB_Click;
             Flow5_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow5_Modification_CB.SelectedIndexChanged += Flow5_Modification_CB_SelectedIndexChanged;
+            Flow5_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             //
             // label39
             // 
@@ -1127,7 +1127,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Manufacturer_CB.Name = "Flow6_Manufacturer_CB";
             Flow6_Manufacturer_CB.Size = new Size(155, 23);
             Flow6_Manufacturer_CB.TabIndex = 22;
-            Flow6_Manufacturer_CB.SelectedIndexChanged += Flow6_Manufacturer_CB_SelectedIndexChanged;
+            Flow6_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
             Flow6_Manufacturer_CB.Click += ManufacturerCB_Click;
             Flow6_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
@@ -1143,7 +1143,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_ManufactureDate_DTP.Size = new Size(155, 23);
             Flow6_ManufactureDate_DTP.TabIndex = 24;
             Flow6_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow6_ManufactureDate_DTP.ValueChanged += Flow6_ManufactureDate_DTP_ValueChanged;
+            Flow6_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
             //
             // Flow6_ManufactureDate_L
             //
@@ -1173,7 +1173,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Type_CB.Name = "Flow6_Type_CB";
             Flow6_Type_CB.Size = new Size(155, 23);
             Flow6_Type_CB.TabIndex = 20;
-            Flow6_Type_CB.SelectedIndexChanged += Flow6_Type_CB_SelectedIndexChanged;
+            Flow6_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
             Flow6_Type_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_Type_CB.KeyUp += MeterTypeCB_KeyUp;
             Flow6_Type_CB.Click += MeterTypeCB_Click;
@@ -1202,7 +1202,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow6_Modification_CB.Click += ModificationCB_Click;
             Flow6_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow6_Modification_CB.SelectedIndexChanged += Flow6_Modification_CB_SelectedIndexChanged;
+            Flow6_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
             // 
             // label47
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -188,7 +188,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Modification_CB.TabIndex = 24;
             Flow1_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow1_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow1_Modification_CB.Click += Flow1_Modification_CB_Click;
+            Flow1_Modification_CB.Click += ModificationCB_Click;
             Flow1_Modification_CB.DropDownClosed += RestoreComboText;
             Flow1_Modification_CB.SelectedIndexChanged += Flow1_Modification_CB_SelectedIndexChanged;
             //
@@ -461,7 +461,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Modification_CB.TabIndex = 24;
             Flow2_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow2_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow2_Modification_CB.Click += Flow2_Modification_CB_Click;
+            Flow2_Modification_CB.Click += ModificationCB_Click;
             Flow2_Modification_CB.DropDownClosed += RestoreComboText;
             Flow2_Modification_CB.SelectedIndexChanged += Flow2_Modification_CB_SelectedIndexChanged;
             //
@@ -646,7 +646,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Modification_CB.TabIndex = 24;
             Flow3_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow3_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow3_Modification_CB.Click += Flow3_Modification_CB_Click;
+            Flow3_Modification_CB.Click += ModificationCB_Click;
             Flow3_Modification_CB.DropDownClosed += RestoreComboText;
             Flow3_Modification_CB.SelectedIndexChanged += Flow3_Modification_CB_SelectedIndexChanged;
             //
@@ -831,7 +831,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Modification_CB.TabIndex = 24;
             Flow4_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow4_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow4_Modification_CB.Click += Flow4_Modification_CB_Click;
+            Flow4_Modification_CB.Click += ModificationCB_Click;
             Flow4_Modification_CB.DropDownClosed += RestoreComboText;
             Flow4_Modification_CB.SelectedIndexChanged += Flow4_Modification_CB_SelectedIndexChanged;
             //
@@ -1016,7 +1016,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Modification_CB.TabIndex = 24;
             Flow5_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow5_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow5_Modification_CB.Click += Flow5_Modification_CB_Click;
+            Flow5_Modification_CB.Click += ModificationCB_Click;
             Flow5_Modification_CB.DropDownClosed += RestoreComboText;
             Flow5_Modification_CB.SelectedIndexChanged += Flow5_Modification_CB_SelectedIndexChanged;
             //
@@ -1201,7 +1201,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Modification_CB.TabIndex = 24;
             Flow6_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow6_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow6_Modification_CB.Click += Flow6_Modification_CB_Click;
+            Flow6_Modification_CB.Click += ModificationCB_Click;
             Flow6_Modification_CB.DropDownClosed += RestoreComboText;
             Flow6_Modification_CB.SelectedIndexChanged += Flow6_Modification_CB_SelectedIndexChanged;
             // 

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -189,6 +189,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow1_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow1_Modification_CB.Click += Flow1_Modification_CB_Click;
+            Flow1_Modification_CB.DropDownClosed += RestoreComboText;
             Flow1_Modification_CB.SelectedIndexChanged += Flow1_Modification_CB_SelectedIndexChanged;
             //
             // label2
@@ -213,6 +214,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow1_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow1_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // GosReestr
             // 
@@ -240,6 +242,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow1_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow1_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow1_ManufactureDate_DTP
             //
@@ -388,6 +391,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow2_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow2_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow2_ManufactureDate_DTP
             //
@@ -433,6 +437,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow2_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow2_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label14
             //
@@ -457,6 +462,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow2_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow2_Modification_CB.Click += Flow2_Modification_CB_Click;
+            Flow2_Modification_CB.DropDownClosed += RestoreComboText;
             Flow2_Modification_CB.SelectedIndexChanged += Flow2_Modification_CB_SelectedIndexChanged;
             //
             // label16
@@ -571,6 +577,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow3_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow3_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow3_ManufactureDate_DTP
             //
@@ -616,6 +623,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow3_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow3_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label21
             //
@@ -639,6 +647,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow3_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow3_Modification_CB.Click += Flow3_Modification_CB_Click;
+            Flow3_Modification_CB.DropDownClosed += RestoreComboText;
             Flow3_Modification_CB.SelectedIndexChanged += Flow3_Modification_CB_SelectedIndexChanged;
             //
             // label23
@@ -753,6 +762,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow4_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow4_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow4_ManufactureDate_DTP
             //
@@ -798,6 +808,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow4_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow4_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label29
             //
@@ -821,6 +832,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow4_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow4_Modification_CB.Click += Flow4_Modification_CB_Click;
+            Flow4_Modification_CB.DropDownClosed += RestoreComboText;
             Flow4_Modification_CB.SelectedIndexChanged += Flow4_Modification_CB_SelectedIndexChanged;
             //
             // label31
@@ -935,6 +947,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow5_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow5_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow5_ManufactureDate_DTP
             //
@@ -980,6 +993,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow5_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow5_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label37
             //
@@ -1003,6 +1017,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow5_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow5_Modification_CB.Click += Flow5_Modification_CB_Click;
+            Flow5_Modification_CB.DropDownClosed += RestoreComboText;
             Flow5_Modification_CB.SelectedIndexChanged += Flow5_Modification_CB_SelectedIndexChanged;
             //
             // label39
@@ -1117,6 +1132,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_GosReestr_CB.Click += ManufacturerCB_Click;
             Flow6_GosReestr_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_GosReestr_CB.KeyUp += ManufacturerCB_KeyUp;
+            Flow6_GosReestr_CB.DropDownClosed += RestoreComboText;
             //
             // Flow6_ManufactureDate_DTP
             //
@@ -1162,6 +1178,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow6_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow6_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label45
             //
@@ -1185,6 +1202,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
             Flow6_Modification_CB.KeyDown += ModificationCB_KeyDown;
             Flow6_Modification_CB.Click += Flow6_Modification_CB_Click;
+            Flow6_Modification_CB.DropDownClosed += RestoreComboText;
             Flow6_Modification_CB.SelectedIndexChanged += Flow6_Modification_CB_SelectedIndexChanged;
             // 
             // label47

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -324,7 +324,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer1_CB.TabIndex = 36;
             Rashodomer1_CB.Text = "Установлен";
             Rashodomer1_CB.UseVisualStyleBackColor = true;
-            Rashodomer1_CB.CheckedChanged += Rashodomer1_CB_CheckedChanged;
+            Rashodomer1_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Rashodomer2_GB
             // 
@@ -373,7 +373,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer2_CB.TabIndex = 45;
             Rashodomer2_CB.Text = "Установлен";
             Rashodomer2_CB.UseVisualStyleBackColor = true;
-            Rashodomer2_CB.CheckedChanged += Rashodomer2_CB_CheckedChanged;
+            Rashodomer2_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Flow2_GosReestr_CB
             //
@@ -559,7 +559,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer3_CB.TabIndex = 46;
             Rashodomer3_CB.Text = "Установлен";
             Rashodomer3_CB.UseVisualStyleBackColor = true;
-            Rashodomer3_CB.CheckedChanged += Rashodomer3_CB_CheckedChanged;
+            Rashodomer3_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Flow3_GosReestr_CB
             //
@@ -744,7 +744,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer4_CB.TabIndex = 47;
             Rashodomer4_CB.Text = "Установлен";
             Rashodomer4_CB.UseVisualStyleBackColor = true;
-            Rashodomer4_CB.CheckedChanged += Rashodomer4_CB_CheckedChanged;
+            Rashodomer4_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Flow4_GosReestr_CB
             //
@@ -929,7 +929,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer5_CB.TabIndex = 48;
             Rashodomer5_CB.Text = "Установлен";
             Rashodomer5_CB.UseVisualStyleBackColor = true;
-            Rashodomer5_CB.CheckedChanged += Rashodomer5_CB_CheckedChanged;
+            Rashodomer5_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Flow5_GosReestr_CB
             //
@@ -1114,7 +1114,7 @@ namespace PoverkaWinForms.Forms.Verifier
             Rashodomer6_CB.TabIndex = 49;
             Rashodomer6_CB.Text = "Установлен";
             Rashodomer6_CB.UseVisualStyleBackColor = true;
-            Rashodomer6_CB.CheckedChanged += Rashodomer6_CB_CheckedChanged;
+            Rashodomer6_CB.CheckedChanged += RashodomerCB_CheckedChanged;
             // 
             // Flow6_GosReestr_CB
             //

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -211,9 +211,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow1_Name_SI_CB.Size = new Size(155, 23);
             Flow1_Name_SI_CB.TabIndex = 20;
             Flow1_Name_SI_CB.SelectedIndexChanged += Flow1_Name_SI_CB_SelectedIndexChanged;
-            Flow1_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow1_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow1_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow1_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow1_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // GosReestr
@@ -434,9 +434,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow2_Name_SI_CB.Size = new Size(155, 23);
             Flow2_Name_SI_CB.TabIndex = 20;
             Flow2_Name_SI_CB.SelectedIndexChanged += Flow2_Name_SI_CB_SelectedIndexChanged;
-            Flow2_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow2_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow2_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow2_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow2_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label14
@@ -620,9 +620,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow3_Name_SI_CB.Size = new Size(155, 23);
             Flow3_Name_SI_CB.TabIndex = 20;
             Flow3_Name_SI_CB.SelectedIndexChanged += Flow3_Name_SI_CB_SelectedIndexChanged;
-            Flow3_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow3_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow3_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow3_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow3_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label21
@@ -805,9 +805,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow4_Name_SI_CB.Size = new Size(155, 23);
             Flow4_Name_SI_CB.TabIndex = 20;
             Flow4_Name_SI_CB.SelectedIndexChanged += Flow4_Name_SI_CB_SelectedIndexChanged;
-            Flow4_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow4_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow4_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow4_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow4_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label29
@@ -990,9 +990,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow5_Name_SI_CB.Size = new Size(155, 23);
             Flow5_Name_SI_CB.TabIndex = 20;
             Flow5_Name_SI_CB.SelectedIndexChanged += Flow5_Name_SI_CB_SelectedIndexChanged;
-            Flow5_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow5_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow5_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow5_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow5_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label37
@@ -1175,9 +1175,9 @@ namespace PoverkaWinForms.Forms.Verifier
             Flow6_Name_SI_CB.Size = new Size(155, 23);
             Flow6_Name_SI_CB.TabIndex = 20;
             Flow6_Name_SI_CB.SelectedIndexChanged += Flow6_Name_SI_CB_SelectedIndexChanged;
-            Flow6_Name_SI_CB.Click += MeterTypeCB_Click;
             Flow6_Name_SI_CB.KeyDown += MeterTypeCB_KeyDown;
             Flow6_Name_SI_CB.KeyUp += MeterTypeCB_KeyUp;
+            Flow6_Name_SI_CB.DropDown += MeterTypeCB_DropDown;
             Flow6_Name_SI_CB.DropDownClosed += RestoreComboText;
             // 
             // label45

--- a/Client/Forms/Verifier/MetersSetupForm.Designer.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.Designer.cs
@@ -28,1379 +28,1379 @@ namespace PoverkaWinForms.Forms.Verifier
         /// </summary>
         private void InitializeComponent()
         {
-            backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
-            Flow1_ZavodskNomer_TB = new TextBox();
-            Flow1_RegistrationNumber_TB = new TextBox();
-            Flow1_RegistrationNumber_Label = new Label();
-            Flow1_ZavodskNomer_Label = new Label();
-            Flow1_Modification_Label = new Label();
-            Flow1_Modification_CB = new ComboBox();
-            Flow1_Type_Label = new Label();
-            Flow1_Type_CB = new ComboBox();
-            Flow1_Manufacturer_Label = new Label();
-            Flow1_Manufacturer_CB = new ComboBox();
-            Flow1_ManufactureDate_DTP = new DateTimePicker();
-            Flow1_ManufactureDate_Label = new Label();
-            label1 = new Label();
-            Flow1_GB = new GroupBox();
-            Flow1_Title_Label = new Label();
-            Flow1_CB = new CheckBox();
-            Flow2_GB = new GroupBox();
-            Flow2_Title_Label = new Label();
-            Flow2_CB = new CheckBox();
-            Flow2_Manufacturer_CB = new ComboBox();
-            Flow2_ManufactureDate_DTP = new DateTimePicker();
-            Flow2_ManufactureDate_Label = new Label();
-            Flow2_Manufacturer_Label = new Label();
-            Flow2_Type_CB = new ComboBox();
-            Flow2_Type_Label = new Label();
-            Flow2_Modification_CB = new ComboBox();
-            Flow2_Modification_Label = new Label();
-            Flow2_ZavodskNomer_TB = new TextBox();
-            Flow2_RegistrationNumber_TB = new TextBox();
-            Flow2_RegistrationNumber_Label = new Label();
-            Flow2_ZavodskNomer_Label = new Label();
-            Flow3_GB = new GroupBox();
-            Flow3_Title_Label = new Label();
-            Flow3_CB = new CheckBox();
-            Flow3_Manufacturer_CB = new ComboBox();
-            Flow3_ManufactureDate_DTP = new DateTimePicker();
-            Flow3_ManufactureDate_Label = new Label();
-            Flow3_Manufacturer_Label = new Label();
-            Flow3_Type_CB = new ComboBox();
-            Flow3_Type_Label = new Label();
-            Flow3_Modification_CB = new ComboBox();
-            Flow3_Modification_Label = new Label();
-            Flow3_ZavodskNomer_TB = new TextBox();
-            Flow3_RegistrationNumber_TB = new TextBox();
-            Flow3_RegistrationNumber_Label = new Label();
-            Flow3_ZavodskNomer_Label = new Label();
-            Flow4_GB = new GroupBox();
-            Flow4_Title_Label = new Label();
-            Flow4_CB = new CheckBox();
-            Flow4_Manufacturer_CB = new ComboBox();
-            Flow4_ManufactureDate_DTP = new DateTimePicker();
-            Flow4_ManufactureDate_Label = new Label();
-            Flow4_Manufacturer_Label = new Label();
-            Flow4_Type_CB = new ComboBox();
-            Flow4_Type_Label = new Label();
-            Flow4_Modification_CB = new ComboBox();
-            Flow4_Modification_Label = new Label();
-            Flow4_ZavodskNomer_TB = new TextBox();
-            Flow4_RegistrationNumber_TB = new TextBox();
-            Flow4_RegistrationNumber_Label = new Label();
-            Flow4_ZavodskNomer_Label = new Label();
-            Flow5_GB = new GroupBox();
-            Flow5_Title_Label = new Label();
-            Flow5_CB = new CheckBox();
-            Flow5_Manufacturer_CB = new ComboBox();
-            Flow5_ManufactureDate_DTP = new DateTimePicker();
-            Flow5_ManufactureDate_Label = new Label();
-            Flow5_Manufacturer_Label = new Label();
-            Flow5_Type_CB = new ComboBox();
-            Flow5_Type_Label = new Label();
-            Flow5_Modification_CB = new ComboBox();
-            Flow5_Modification_Label = new Label();
-            Flow5_ZavodskNomer_TB = new TextBox();
-            Flow5_RegistrationNumber_TB = new TextBox();
-            Flow5_RegistrationNumber_Label = new Label();
-            Flow5_ZavodskNomer_Label = new Label();
-            Flow6_GB = new GroupBox();
-            Flow6_Title_Label = new Label();
-            Flow6_CB = new CheckBox();
-            Flow6_Manufacturer_CB = new ComboBox();
-            Flow6_ManufactureDate_DTP = new DateTimePicker();
-            Flow6_ManufactureDate_Label = new Label();
-            Flow6_Manufacturer_Label = new Label();
-            Flow6_Type_CB = new ComboBox();
-            Flow6_Type_Label = new Label();
-            Flow6_Modification_CB = new ComboBox();
-            Flow6_Modification_Label = new Label();
-            Flow6_ZavodskNomer_TB = new TextBox();
-            Flow6_RegistrationNumber_TB = new TextBox();
-            Flow6_RegistrationNumber_Label = new Label();
-            Flow6_ZavodskNomer_Label = new Label();
-            Next_B = new Button();
-            button1 = new Button();
-            Flow1_GB.SuspendLayout();
-            Flow2_GB.SuspendLayout();
-            Flow3_GB.SuspendLayout();
-            Flow4_GB.SuspendLayout();
-            Flow5_GB.SuspendLayout();
-            Flow6_GB.SuspendLayout();
+            BackgroundWorker = new System.ComponentModel.BackgroundWorker();
+            Flow1FactoryNumberTextBox = new TextBox();
+            Flow1RegistrationNumberTextBox = new TextBox();
+            Flow1RegistrationNumberLabel = new Label();
+            Flow1FactoryNumberLabel = new Label();
+            Flow1ModificationLabel = new Label();
+            Flow1ModificationComboBox = new ComboBox();
+            Flow1TypeLabel = new Label();
+            Flow1TypeComboBox = new ComboBox();
+            Flow1ManufacturerLabel = new Label();
+            Flow1ManufacturerComboBox = new ComboBox();
+            Flow1ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow1ManufactureDateLabel = new Label();
+            HeaderLabel = new Label();
+            Flow1GroupBox = new GroupBox();
+            Flow1TitleLabel = new Label();
+            Flow1CheckBox = new CheckBox();
+            Flow2GroupBox = new GroupBox();
+            Flow2TitleLabel = new Label();
+            Flow2CheckBox = new CheckBox();
+            Flow2ManufacturerComboBox = new ComboBox();
+            Flow2ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow2ManufactureDateLabel = new Label();
+            Flow2ManufacturerLabel = new Label();
+            Flow2TypeComboBox = new ComboBox();
+            Flow2TypeLabel = new Label();
+            Flow2ModificationComboBox = new ComboBox();
+            Flow2ModificationLabel = new Label();
+            Flow2FactoryNumberTextBox = new TextBox();
+            Flow2RegistrationNumberTextBox = new TextBox();
+            Flow2RegistrationNumberLabel = new Label();
+            Flow2FactoryNumberLabel = new Label();
+            Flow3GroupBox = new GroupBox();
+            Flow3TitleLabel = new Label();
+            Flow3CheckBox = new CheckBox();
+            Flow3ManufacturerComboBox = new ComboBox();
+            Flow3ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow3ManufactureDateLabel = new Label();
+            Flow3ManufacturerLabel = new Label();
+            Flow3TypeComboBox = new ComboBox();
+            Flow3TypeLabel = new Label();
+            Flow3ModificationComboBox = new ComboBox();
+            Flow3ModificationLabel = new Label();
+            Flow3FactoryNumberTextBox = new TextBox();
+            Flow3RegistrationNumberTextBox = new TextBox();
+            Flow3RegistrationNumberLabel = new Label();
+            Flow3FactoryNumberLabel = new Label();
+            Flow4GroupBox = new GroupBox();
+            Flow4TitleLabel = new Label();
+            Flow4CheckBox = new CheckBox();
+            Flow4ManufacturerComboBox = new ComboBox();
+            Flow4ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow4ManufactureDateLabel = new Label();
+            Flow4ManufacturerLabel = new Label();
+            Flow4TypeComboBox = new ComboBox();
+            Flow4TypeLabel = new Label();
+            Flow4ModificationComboBox = new ComboBox();
+            Flow4ModificationLabel = new Label();
+            Flow4FactoryNumberTextBox = new TextBox();
+            Flow4RegistrationNumberTextBox = new TextBox();
+            Flow4RegistrationNumberLabel = new Label();
+            Flow4FactoryNumberLabel = new Label();
+            Flow5GroupBox = new GroupBox();
+            Flow5TitleLabel = new Label();
+            Flow5CheckBox = new CheckBox();
+            Flow5ManufacturerComboBox = new ComboBox();
+            Flow5ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow5ManufactureDateLabel = new Label();
+            Flow5ManufacturerLabel = new Label();
+            Flow5TypeComboBox = new ComboBox();
+            Flow5TypeLabel = new Label();
+            Flow5ModificationComboBox = new ComboBox();
+            Flow5ModificationLabel = new Label();
+            Flow5FactoryNumberTextBox = new TextBox();
+            Flow5RegistrationNumberTextBox = new TextBox();
+            Flow5RegistrationNumberLabel = new Label();
+            Flow5FactoryNumberLabel = new Label();
+            Flow6GroupBox = new GroupBox();
+            Flow6TitleLabel = new Label();
+            Flow6CheckBox = new CheckBox();
+            Flow6ManufacturerComboBox = new ComboBox();
+            Flow6ManufactureDateDateTimePicker = new DateTimePicker();
+            Flow6ManufactureDateLabel = new Label();
+            Flow6ManufacturerLabel = new Label();
+            Flow6TypeComboBox = new ComboBox();
+            Flow6TypeLabel = new Label();
+            Flow6ModificationComboBox = new ComboBox();
+            Flow6ModificationLabel = new Label();
+            Flow6FactoryNumberTextBox = new TextBox();
+            Flow6RegistrationNumberTextBox = new TextBox();
+            Flow6RegistrationNumberLabel = new Label();
+            Flow6FactoryNumberLabel = new Label();
+            NextButton = new Button();
+            ExitButton = new Button();
+            Flow1GroupBox.SuspendLayout();
+            Flow2GroupBox.SuspendLayout();
+            Flow3GroupBox.SuspendLayout();
+            Flow4GroupBox.SuspendLayout();
+            Flow5GroupBox.SuspendLayout();
+            Flow6GroupBox.SuspendLayout();
             SuspendLayout();
             // 
-            // Flow1_ZavodskNomer_TB
-            //
-            Flow1_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow1_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow1_ZavodskNomer_TB.Name = "Flow1_ZavodskNomer_TB";
-            Flow1_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow1_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow1_RegistrationNumber_TB
-            //
-            Flow1_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow1_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow1_RegistrationNumber_TB.Name = "Flow1_RegistrationNumber_TB";
-            Flow1_RegistrationNumber_TB.ReadOnly = true;
-            Flow1_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow1_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow1_RegistrationNumber_Label
-            //
-            Flow1_RegistrationNumber_Label.AutoSize = true;
-            Flow1_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow1_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_RegistrationNumber_Label.Name = "Flow1_RegistrationNumber_Label";
-            Flow1_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow1_RegistrationNumber_Label.TabIndex = 26;
-            Flow1_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow1_ZavodskNomer_Label
-            //
-            Flow1_ZavodskNomer_Label.AutoSize = true;
-            Flow1_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow1_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_ZavodskNomer_Label.Name = "Flow1_ZavodskNomer_Label";
-            Flow1_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow1_ZavodskNomer_Label.TabIndex = 29;
-            Flow1_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Flow1_Modification_Label
-            // 
-            Flow1_Modification_Label.AutoSize = true;
-            Flow1_Modification_Label.Location = new Point(18, 130);
-            Flow1_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_Modification_Label.Name = "Flow1_Modification_Label";
-            Flow1_Modification_Label.Size = new Size(86, 15);
-            Flow1_Modification_Label.TabIndex = 25;
-            Flow1_Modification_Label.Text = "Модификация";
-            //
-            // Flow1_Modification_CB
-            //
-            Flow1_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow1_Modification_CB.FormattingEnabled = true;
-            Flow1_Modification_CB.Location = new Point(168, 126);
-            Flow1_Modification_CB.Margin = new Padding(4);
-            Flow1_Modification_CB.Name = "Flow1_Modification_CB";
-            Flow1_Modification_CB.Size = new Size(155, 23);
-            Flow1_Modification_CB.TabIndex = 24;
-            Flow1_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow1_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow1_Modification_CB.Click += ModificationCB_Click;
-            Flow1_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow1_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            //
-            // Flow1_Type_Label
-            //
-            Flow1_Type_Label.AutoSize = true;
-            Flow1_Type_Label.Location = new Point(18, 40);
-            Flow1_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_Type_Label.Name = "Flow1_Type_Label";
-            Flow1_Type_Label.Size = new Size(28, 15);
-            Flow1_Type_Label.TabIndex = 21;
-            Flow1_Type_Label.Text = "Тип";
-            // 
-            // Flow1_Type_CB
-            // 
-            Flow1_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow1_Type_CB.Location = new Point(168, 38);
-            Flow1_Type_CB.Margin = new Padding(4);
-            Flow1_Type_CB.Name = "Flow1_Type_CB";
-            Flow1_Type_CB.Size = new Size(155, 23);
-            Flow1_Type_CB.TabIndex = 20;
-            Flow1_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow1_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow1_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow1_Type_CB.Click += MeterTypeCB_Click;
-            Flow1_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow1_Manufacturer_Label
-            // 
-            Flow1_Manufacturer_Label.AutoSize = true;
-            Flow1_Manufacturer_Label.Location = new Point(18, 70);
-            Flow1_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_Manufacturer_Label.Name = "Flow1_Manufacturer_Label";
-            Flow1_Manufacturer_Label.Size = new Size(92, 15);
-            Flow1_Manufacturer_Label.TabIndex = 23;
-            Flow1_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow1_Manufacturer_CB
-            // 
-            Flow1_Manufacturer_CB.AllowDrop = true;
-            Flow1_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow1_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow1_Manufacturer_CB.FormattingEnabled = true;
-            Flow1_Manufacturer_CB.IntegralHeight = false;
-            Flow1_Manufacturer_CB.Location = new Point(168, 67);
-            Flow1_Manufacturer_CB.Margin = new Padding(4);
-            Flow1_Manufacturer_CB.Name = "Flow1_Manufacturer_CB";
-            Flow1_Manufacturer_CB.Size = new Size(155, 23);
-            Flow1_Manufacturer_CB.TabIndex = 22;
-            Flow1_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow1_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow1_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow1_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow1_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow1_ManufactureDate_DTP
-            //
-            Flow1_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow1_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow1_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow1_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow1_ManufactureDate_DTP.Name = "Flow1_ManufactureDate_DTP";
-            Flow1_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow1_ManufactureDate_DTP.TabIndex = 24;
-            Flow1_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow1_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow1_ManufactureDate_Label
-            //
-            Flow1_ManufactureDate_Label.AutoSize = true;
-            Flow1_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow1_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_ManufactureDate_Label.Name = "Flow1_ManufactureDate_Label";
-            Flow1_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow1_ManufactureDate_Label.TabIndex = 24;
-            Flow1_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // label1
-            //
-            label1.AutoSize = true;
-            label1.Font = new Font("Microsoft Sans Serif", 20F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            label1.Location = new Point(192, 22);
-            label1.Margin = new Padding(4, 0, 4, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(710, 31);
-            label1.TabIndex = 19;
-            label1.Text = "Настройка параметров поверяемых преобразователей";
-            // 
-            // Flow1_GB
-            // 
-            Flow1_GB.Controls.Add(Flow1_Title_Label);
-            Flow1_GB.Controls.Add(Flow1_CB);
-            Flow1_GB.Controls.Add(Flow1_Manufacturer_CB);
-            Flow1_GB.Controls.Add(Flow1_ManufactureDate_DTP);
-            Flow1_GB.Controls.Add(Flow1_ManufactureDate_Label);
-            Flow1_GB.Controls.Add(Flow1_Manufacturer_Label);
-            Flow1_GB.Controls.Add(Flow1_Type_CB);
-            Flow1_GB.Controls.Add(Flow1_Type_Label);
-            Flow1_GB.Controls.Add(Flow1_Modification_CB);
-            Flow1_GB.Controls.Add(Flow1_Modification_Label);
-            Flow1_GB.Controls.Add(Flow1_RegistrationNumber_TB);
-            Flow1_GB.Controls.Add(Flow1_RegistrationNumber_Label);
-            Flow1_GB.Controls.Add(Flow1_ZavodskNomer_TB);
-            Flow1_GB.Controls.Add(Flow1_ZavodskNomer_Label);
-            Flow1_GB.Location = new Point(60, 56);
-            Flow1_GB.Margin = new Padding(4);
-            Flow1_GB.Name = "Flow1_GB";
-            Flow1_GB.Padding = new Padding(4);
-            Flow1_GB.Size = new Size(342, 281);
-            Flow1_GB.TabIndex = 34;
-            Flow1_GB.TabStop = false;
-            Flow1_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow1_Title_Label
-            // 
-            Flow1_Title_Label.AutoSize = true;
-            Flow1_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow1_Title_Label.Location = new Point(18, 0);
-            Flow1_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow1_Title_Label.Name = "Flow1_Title_Label";
-            Flow1_Title_Label.Size = new Size(156, 24);
-            Flow1_Title_Label.TabIndex = 35;
-            Flow1_Title_Label.Text = "Расходомер №1";
-            // 
-            // Flow1_CB
-            // 
-            Flow1_CB.AutoSize = true;
-            Flow1_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow1_CB.Location = new Point(228, 0);
-            Flow1_CB.Margin = new Padding(4);
-            Flow1_CB.Name = "Flow1_CB";
-            Flow1_CB.Size = new Size(97, 17);
-            Flow1_CB.TabIndex = 36;
-            Flow1_CB.Text = "Установлен";
-            Flow1_CB.UseVisualStyleBackColor = true;
-            Flow1_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow2_GB
-            // 
-            Flow2_GB.Controls.Add(Flow2_Title_Label);
-            Flow2_GB.Controls.Add(Flow2_CB);
-            Flow2_GB.Controls.Add(Flow2_Manufacturer_CB);
-            Flow2_GB.Controls.Add(Flow2_ManufactureDate_DTP);
-            Flow2_GB.Controls.Add(Flow2_ManufactureDate_Label);
-            Flow2_GB.Controls.Add(Flow2_Manufacturer_Label);
-            Flow2_GB.Controls.Add(Flow2_Type_CB);
-            Flow2_GB.Controls.Add(Flow2_Type_Label);
-            Flow2_GB.Controls.Add(Flow2_Modification_CB);
-            Flow2_GB.Controls.Add(Flow2_Modification_Label);
-            Flow2_GB.Controls.Add(Flow2_RegistrationNumber_TB);
-            Flow2_GB.Controls.Add(Flow2_RegistrationNumber_Label);
-            Flow2_GB.Controls.Add(Flow2_ZavodskNomer_TB);
-            Flow2_GB.Controls.Add(Flow2_ZavodskNomer_Label);
-            Flow2_GB.Location = new Point(60, 346);
-            Flow2_GB.Margin = new Padding(4);
-            Flow2_GB.Name = "Flow2_GB";
-            Flow2_GB.Padding = new Padding(4);
-            Flow2_GB.Size = new Size(342, 281);
-            Flow2_GB.TabIndex = 36;
-            Flow2_GB.TabStop = false;
-            Flow2_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow2_Title_Label
-            // 
-            Flow2_Title_Label.AutoSize = true;
-            Flow2_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow2_Title_Label.Location = new Point(18, 0);
-            Flow2_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_Title_Label.Name = "Flow2_Title_Label";
-            Flow2_Title_Label.Size = new Size(156, 24);
-            Flow2_Title_Label.TabIndex = 35;
-            Flow2_Title_Label.Text = "Расходомер №2";
-            // 
-            // Flow2_CB
-            // 
-            Flow2_CB.AutoSize = true;
-            Flow2_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow2_CB.Location = new Point(228, 0);
-            Flow2_CB.Margin = new Padding(4);
-            Flow2_CB.Name = "Flow2_CB";
-            Flow2_CB.Size = new Size(97, 17);
-            Flow2_CB.TabIndex = 45;
-            Flow2_CB.Text = "Установлен";
-            Flow2_CB.UseVisualStyleBackColor = true;
-            Flow2_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow2_Manufacturer_CB
-            //
-            Flow2_Manufacturer_CB.AllowDrop = true;
-            Flow2_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow2_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow2_Manufacturer_CB.FormattingEnabled = true;
-            Flow2_Manufacturer_CB.IntegralHeight = false;
-            Flow2_Manufacturer_CB.Location = new Point(168, 67);
-            Flow2_Manufacturer_CB.Margin = new Padding(4);
-            Flow2_Manufacturer_CB.Name = "Flow2_Manufacturer_CB";
-            Flow2_Manufacturer_CB.Size = new Size(155, 23);
-            Flow2_Manufacturer_CB.TabIndex = 22;
-            Flow2_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow2_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow2_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow2_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow2_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow2_ManufactureDate_DTP
-            //
-            Flow2_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow2_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow2_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow2_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow2_ManufactureDate_DTP.Name = "Flow2_ManufactureDate_DTP";
-            Flow2_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow2_ManufactureDate_DTP.TabIndex = 24;
-            Flow2_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow2_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow2_ManufactureDate_Label
-            //
-            Flow2_ManufactureDate_Label.AutoSize = true;
-            Flow2_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow2_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_ManufactureDate_Label.Name = "Flow2_ManufactureDate_Label";
-            Flow2_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow2_ManufactureDate_Label.TabIndex = 24;
-            Flow2_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // Flow2_Manufacturer_Label
-            //
-            Flow2_Manufacturer_Label.AutoSize = true;
-            Flow2_Manufacturer_Label.Location = new Point(18, 70);
-            Flow2_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_Manufacturer_Label.Name = "Flow2_Manufacturer_Label";
-            Flow2_Manufacturer_Label.Size = new Size(92, 15);
-            Flow2_Manufacturer_Label.TabIndex = 23;
-            Flow2_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow2_Type_CB
-            //
-            Flow2_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow2_Type_CB.Location = new Point(168, 38);
-            Flow2_Type_CB.Margin = new Padding(4);
-            Flow2_Type_CB.Name = "Flow2_Type_CB";
-            Flow2_Type_CB.Size = new Size(155, 23);
-            Flow2_Type_CB.TabIndex = 20;
-            Flow2_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow2_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow2_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow2_Type_CB.Click += MeterTypeCB_Click;
-            Flow2_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow2_Type_Label
-            //
-            Flow2_Type_Label.AutoSize = true;
-            Flow2_Type_Label.Location = new Point(18, 40);
-            Flow2_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_Type_Label.Name = "Flow2_Type_Label";
-            Flow2_Type_Label.Size = new Size(28, 15);
-            Flow2_Type_Label.TabIndex = 21;
-            Flow2_Type_Label.Text = "Тип";
-            //
-            // Flow2_Modification_CB
-            //
-            Flow2_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow2_Modification_CB.FormattingEnabled = true;
-            Flow2_Modification_CB.Location = new Point(168, 126);
-            Flow2_Modification_CB.Margin = new Padding(4);
-            Flow2_Modification_CB.Name = "Flow2_Modification_CB";
-            Flow2_Modification_CB.Size = new Size(155, 23);
-            Flow2_Modification_CB.TabIndex = 24;
-            Flow2_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow2_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow2_Modification_CB.Click += ModificationCB_Click;
-            Flow2_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow2_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            //
-            // Flow2_Modification_Label
-            // 
-            Flow2_Modification_Label.AutoSize = true;
-            Flow2_Modification_Label.Location = new Point(18, 130);
-            Flow2_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_Modification_Label.Name = "Flow2_Modification_Label";
-            Flow2_Modification_Label.Size = new Size(86, 15);
-            Flow2_Modification_Label.TabIndex = 25;
-            Flow2_Modification_Label.Text = "Модификация";
-            // 
-            // Flow2_ZavodskNomer_TB
-            //
-            Flow2_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow2_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow2_ZavodskNomer_TB.Name = "Flow2_ZavodskNomer_TB";
-            Flow2_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow2_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow2_RegistrationNumber_TB
-            //
-            Flow2_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow2_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow2_RegistrationNumber_TB.Name = "Flow2_RegistrationNumber_TB";
-            Flow2_RegistrationNumber_TB.ReadOnly = true;
-            Flow2_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow2_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow2_RegistrationNumber_Label
-            //
-            Flow2_RegistrationNumber_Label.AutoSize = true;
-            Flow2_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow2_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_RegistrationNumber_Label.Name = "Flow2_RegistrationNumber_Label";
-            Flow2_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow2_RegistrationNumber_Label.TabIndex = 26;
-            Flow2_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow2_ZavodskNomer_Label
-            //
-            Flow2_ZavodskNomer_Label.AutoSize = true;
-            Flow2_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow2_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow2_ZavodskNomer_Label.Name = "Flow2_ZavodskNomer_Label";
-            Flow2_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow2_ZavodskNomer_Label.TabIndex = 29;
-            Flow2_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Flow3_GB
-            // 
-            Flow3_GB.Controls.Add(Flow3_Title_Label);
-            Flow3_GB.Controls.Add(Flow3_CB);
-            Flow3_GB.Controls.Add(Flow3_Manufacturer_CB);
-            Flow3_GB.Controls.Add(Flow3_ManufactureDate_DTP);
-            Flow3_GB.Controls.Add(Flow3_ManufactureDate_Label);
-            Flow3_GB.Controls.Add(Flow3_Manufacturer_Label);
-            Flow3_GB.Controls.Add(Flow3_Type_CB);
-            Flow3_GB.Controls.Add(Flow3_Type_Label);
-            Flow3_GB.Controls.Add(Flow3_Modification_CB);
-            Flow3_GB.Controls.Add(Flow3_Modification_Label);
-            Flow3_GB.Controls.Add(Flow3_RegistrationNumber_TB);
-            Flow3_GB.Controls.Add(Flow3_RegistrationNumber_Label);
-            Flow3_GB.Controls.Add(Flow3_ZavodskNomer_TB);
-            Flow3_GB.Controls.Add(Flow3_ZavodskNomer_Label);
-            Flow3_GB.Location = new Point(409, 56);
-            Flow3_GB.Margin = new Padding(4);
-            Flow3_GB.Name = "Flow3_GB";
-            Flow3_GB.Padding = new Padding(4);
-            Flow3_GB.Size = new Size(342, 281);
-            Flow3_GB.TabIndex = 37;
-            Flow3_GB.TabStop = false;
-            Flow3_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow3_Title_Label
-            // 
-            Flow3_Title_Label.AutoSize = true;
-            Flow3_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow3_Title_Label.Location = new Point(18, 0);
-            Flow3_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_Title_Label.Name = "Flow3_Title_Label";
-            Flow3_Title_Label.Size = new Size(156, 24);
-            Flow3_Title_Label.TabIndex = 35;
-            Flow3_Title_Label.Text = "Расходомер №3";
-            // 
-            // Flow3_CB
-            // 
-            Flow3_CB.AutoSize = true;
-            Flow3_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow3_CB.Location = new Point(228, 0);
-            Flow3_CB.Margin = new Padding(4);
-            Flow3_CB.Name = "Flow3_CB";
-            Flow3_CB.Size = new Size(97, 17);
-            Flow3_CB.TabIndex = 46;
-            Flow3_CB.Text = "Установлен";
-            Flow3_CB.UseVisualStyleBackColor = true;
-            Flow3_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow3_Manufacturer_CB
-            //
-            Flow3_Manufacturer_CB.AllowDrop = true;
-            Flow3_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow3_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow3_Manufacturer_CB.FormattingEnabled = true;
-            Flow3_Manufacturer_CB.IntegralHeight = false;
-            Flow3_Manufacturer_CB.Location = new Point(168, 67);
-            Flow3_Manufacturer_CB.Margin = new Padding(4);
-            Flow3_Manufacturer_CB.Name = "Flow3_Manufacturer_CB";
-            Flow3_Manufacturer_CB.Size = new Size(155, 23);
-            Flow3_Manufacturer_CB.TabIndex = 22;
-            Flow3_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow3_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow3_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow3_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow3_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow3_ManufactureDate_DTP
-            //
-            Flow3_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow3_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow3_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow3_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow3_ManufactureDate_DTP.Name = "Flow3_ManufactureDate_DTP";
-            Flow3_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow3_ManufactureDate_DTP.TabIndex = 24;
-            Flow3_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow3_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow3_ManufactureDate_Label
-            //
-            Flow3_ManufactureDate_Label.AutoSize = true;
-            Flow3_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow3_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_ManufactureDate_Label.Name = "Flow3_ManufactureDate_Label";
-            Flow3_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow3_ManufactureDate_Label.TabIndex = 24;
-            Flow3_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // Flow3_Manufacturer_Label
-            //
-            Flow3_Manufacturer_Label.AutoSize = true;
-            Flow3_Manufacturer_Label.Location = new Point(18, 70);
-            Flow3_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_Manufacturer_Label.Name = "Flow3_Manufacturer_Label";
-            Flow3_Manufacturer_Label.Size = new Size(92, 15);
-            Flow3_Manufacturer_Label.TabIndex = 23;
-            Flow3_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow3_Type_CB
-            //
-            Flow3_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow3_Type_CB.Location = new Point(168, 38);
-            Flow3_Type_CB.Margin = new Padding(4);
-            Flow3_Type_CB.Name = "Flow3_Type_CB";
-            Flow3_Type_CB.Size = new Size(155, 23);
-            Flow3_Type_CB.TabIndex = 20;
-            Flow3_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow3_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow3_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow3_Type_CB.Click += MeterTypeCB_Click;
-            Flow3_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow3_Type_Label
-            //
-            Flow3_Type_Label.AutoSize = true;
-            Flow3_Type_Label.Location = new Point(18, 40);
-            Flow3_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_Type_Label.Name = "Flow3_Type_Label";
-            Flow3_Type_Label.Size = new Size(28, 15);
-            Flow3_Type_Label.TabIndex = 21;
-            Flow3_Type_Label.Text = "Тип";
-            // 
-            // Flow3_Modification_CB
-            //
-            Flow3_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow3_Modification_CB.FormattingEnabled = true;
-            Flow3_Modification_CB.Location = new Point(168, 126);
-            Flow3_Modification_CB.Margin = new Padding(4);
-            Flow3_Modification_CB.Name = "Flow3_Modification_CB";
-            Flow3_Modification_CB.Size = new Size(155, 23);
-            Flow3_Modification_CB.TabIndex = 24;
-            Flow3_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow3_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow3_Modification_CB.Click += ModificationCB_Click;
-            Flow3_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow3_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            //
-            // Flow3_Modification_Label
-            // 
-            Flow3_Modification_Label.AutoSize = true;
-            Flow3_Modification_Label.Location = new Point(18, 130);
-            Flow3_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_Modification_Label.Name = "Flow3_Modification_Label";
-            Flow3_Modification_Label.Size = new Size(86, 15);
-            Flow3_Modification_Label.TabIndex = 25;
-            Flow3_Modification_Label.Text = "Модификация";
-            // 
-            // Flow3_ZavodskNomer_TB
-            //
-            Flow3_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow3_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow3_ZavodskNomer_TB.Name = "Flow3_ZavodskNomer_TB";
-            Flow3_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow3_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow3_RegistrationNumber_TB
-            //
-            Flow3_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow3_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow3_RegistrationNumber_TB.Name = "Flow3_RegistrationNumber_TB";
-            Flow3_RegistrationNumber_TB.ReadOnly = true;
-            Flow3_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow3_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow3_RegistrationNumber_Label
-            //
-            Flow3_RegistrationNumber_Label.AutoSize = true;
-            Flow3_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow3_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_RegistrationNumber_Label.Name = "Flow3_RegistrationNumber_Label";
-            Flow3_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow3_RegistrationNumber_Label.TabIndex = 26;
-            Flow3_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow3_ZavodskNomer_Label
-            //
-            Flow3_ZavodskNomer_Label.AutoSize = true;
-            Flow3_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow3_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow3_ZavodskNomer_Label.Name = "Flow3_ZavodskNomer_Label";
-            Flow3_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow3_ZavodskNomer_Label.TabIndex = 29;
-            Flow3_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Flow4_GB
-            // 
-            Flow4_GB.Controls.Add(Flow4_Title_Label);
-            Flow4_GB.Controls.Add(Flow4_CB);
-            Flow4_GB.Controls.Add(Flow4_Manufacturer_CB);
-            Flow4_GB.Controls.Add(Flow4_ManufactureDate_DTP);
-            Flow4_GB.Controls.Add(Flow4_ManufactureDate_Label);
-            Flow4_GB.Controls.Add(Flow4_Manufacturer_Label);
-            Flow4_GB.Controls.Add(Flow4_Type_CB);
-            Flow4_GB.Controls.Add(Flow4_Type_Label);
-            Flow4_GB.Controls.Add(Flow4_Modification_CB);
-            Flow4_GB.Controls.Add(Flow4_Modification_Label);
-            Flow4_GB.Controls.Add(Flow4_RegistrationNumber_TB);
-            Flow4_GB.Controls.Add(Flow4_RegistrationNumber_Label);
-            Flow4_GB.Controls.Add(Flow4_ZavodskNomer_TB);
-            Flow4_GB.Controls.Add(Flow4_ZavodskNomer_Label);
-            Flow4_GB.Location = new Point(409, 346);
-            Flow4_GB.Margin = new Padding(4);
-            Flow4_GB.Name = "Flow4_GB";
-            Flow4_GB.Padding = new Padding(4);
-            Flow4_GB.Size = new Size(342, 281);
-            Flow4_GB.TabIndex = 38;
-            Flow4_GB.TabStop = false;
-            Flow4_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow4_Title_Label
-            // 
-            Flow4_Title_Label.AutoSize = true;
-            Flow4_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow4_Title_Label.Location = new Point(18, 0);
-            Flow4_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_Title_Label.Name = "Flow4_Title_Label";
-            Flow4_Title_Label.Size = new Size(156, 24);
-            Flow4_Title_Label.TabIndex = 35;
-            Flow4_Title_Label.Text = "Расходомер №4";
-            // 
-            // Flow4_CB
-            // 
-            Flow4_CB.AutoSize = true;
-            Flow4_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow4_CB.Location = new Point(228, 0);
-            Flow4_CB.Margin = new Padding(4);
-            Flow4_CB.Name = "Flow4_CB";
-            Flow4_CB.Size = new Size(97, 17);
-            Flow4_CB.TabIndex = 47;
-            Flow4_CB.Text = "Установлен";
-            Flow4_CB.UseVisualStyleBackColor = true;
-            Flow4_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow4_Manufacturer_CB
-            //
-            Flow4_Manufacturer_CB.AllowDrop = true;
-            Flow4_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow4_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow4_Manufacturer_CB.FormattingEnabled = true;
-            Flow4_Manufacturer_CB.IntegralHeight = false;
-            Flow4_Manufacturer_CB.Location = new Point(168, 67);
-            Flow4_Manufacturer_CB.Margin = new Padding(4);
-            Flow4_Manufacturer_CB.Name = "Flow4_Manufacturer_CB";
-            Flow4_Manufacturer_CB.Size = new Size(155, 23);
-            Flow4_Manufacturer_CB.TabIndex = 22;
-            Flow4_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow4_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow4_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow4_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow4_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow4_ManufactureDate_DTP
-            //
-            Flow4_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow4_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow4_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow4_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow4_ManufactureDate_DTP.Name = "Flow4_ManufactureDate_DTP";
-            Flow4_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow4_ManufactureDate_DTP.TabIndex = 24;
-            Flow4_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow4_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow4_ManufactureDate_Label
-            //
-            Flow4_ManufactureDate_Label.AutoSize = true;
-            Flow4_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow4_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_ManufactureDate_Label.Name = "Flow4_ManufactureDate_Label";
-            Flow4_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow4_ManufactureDate_Label.TabIndex = 24;
-            Flow4_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // Flow4_Manufacturer_Label
-            //
-            Flow4_Manufacturer_Label.AutoSize = true;
-            Flow4_Manufacturer_Label.Location = new Point(18, 70);
-            Flow4_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_Manufacturer_Label.Name = "Flow4_Manufacturer_Label";
-            Flow4_Manufacturer_Label.Size = new Size(92, 15);
-            Flow4_Manufacturer_Label.TabIndex = 23;
-            Flow4_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow4_Type_CB
-            //
-            Flow4_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow4_Type_CB.Location = new Point(168, 38);
-            Flow4_Type_CB.Margin = new Padding(4);
-            Flow4_Type_CB.Name = "Flow4_Type_CB";
-            Flow4_Type_CB.Size = new Size(155, 23);
-            Flow4_Type_CB.TabIndex = 20;
-            Flow4_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow4_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow4_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow4_Type_CB.Click += MeterTypeCB_Click;
-            Flow4_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow4_Type_Label
-            //
-            Flow4_Type_Label.AutoSize = true;
-            Flow4_Type_Label.Location = new Point(18, 40);
-            Flow4_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_Type_Label.Name = "Flow4_Type_Label";
-            Flow4_Type_Label.Size = new Size(117, 15);
-            Flow4_Type_Label.TabIndex = 21;
-            Flow4_Type_Label.Text = "Тип";
-            // 
-            // Flow4_Modification_CB
-            //
-            Flow4_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow4_Modification_CB.FormattingEnabled = true;
-            Flow4_Modification_CB.Location = new Point(168, 126);
-            Flow4_Modification_CB.Margin = new Padding(4);
-            Flow4_Modification_CB.Name = "Flow4_Modification_CB";
-            Flow4_Modification_CB.Size = new Size(155, 23);
-            Flow4_Modification_CB.TabIndex = 24;
-            Flow4_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow4_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow4_Modification_CB.Click += ModificationCB_Click;
-            Flow4_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow4_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            //
-            // Flow4_Modification_Label
-            // 
-            Flow4_Modification_Label.AutoSize = true;
-            Flow4_Modification_Label.Location = new Point(18, 130);
-            Flow4_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_Modification_Label.Name = "Flow4_Modification_Label";
-            Flow4_Modification_Label.Size = new Size(86, 15);
-            Flow4_Modification_Label.TabIndex = 25;
-            Flow4_Modification_Label.Text = "Модификация";
-            // 
-            // Flow4_ZavodskNomer_TB
-            //
-            Flow4_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow4_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow4_ZavodskNomer_TB.Name = "Flow4_ZavodskNomer_TB";
-            Flow4_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow4_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow4_RegistrationNumber_TB
-            //
-            Flow4_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow4_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow4_RegistrationNumber_TB.Name = "Flow4_RegistrationNumber_TB";
-            Flow4_RegistrationNumber_TB.ReadOnly = true;
-            Flow4_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow4_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow4_RegistrationNumber_Label
-            //
-            Flow4_RegistrationNumber_Label.AutoSize = true;
-            Flow4_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow4_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_RegistrationNumber_Label.Name = "Flow4_RegistrationNumber_Label";
-            Flow4_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow4_RegistrationNumber_Label.TabIndex = 26;
-            Flow4_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow4_ZavodskNomer_Label
-            //
-            Flow4_ZavodskNomer_Label.AutoSize = true;
-            Flow4_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow4_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow4_ZavodskNomer_Label.Name = "Flow4_ZavodskNomer_Label";
-            Flow4_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow4_ZavodskNomer_Label.TabIndex = 29;
-            Flow4_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Flow5_GB
-            // 
-            Flow5_GB.Controls.Add(Flow5_Title_Label);
-            Flow5_GB.Controls.Add(Flow5_CB);
-            Flow5_GB.Controls.Add(Flow5_Manufacturer_CB);
-            Flow5_GB.Controls.Add(Flow5_ManufactureDate_DTP);
-            Flow5_GB.Controls.Add(Flow5_ManufactureDate_Label);
-            Flow5_GB.Controls.Add(Flow5_Manufacturer_Label);
-            Flow5_GB.Controls.Add(Flow5_Type_CB);
-            Flow5_GB.Controls.Add(Flow5_Type_Label);
-            Flow5_GB.Controls.Add(Flow5_Modification_CB);
-            Flow5_GB.Controls.Add(Flow5_Modification_Label);
-            Flow5_GB.Controls.Add(Flow5_RegistrationNumber_TB);
-            Flow5_GB.Controls.Add(Flow5_RegistrationNumber_Label);
-            Flow5_GB.Controls.Add(Flow5_ZavodskNomer_TB);
-            Flow5_GB.Controls.Add(Flow5_ZavodskNomer_Label);
-            Flow5_GB.Location = new Point(757, 56);
-            Flow5_GB.Margin = new Padding(4);
-            Flow5_GB.Name = "Flow5_GB";
-            Flow5_GB.Padding = new Padding(4);
-            Flow5_GB.Size = new Size(342, 281);
-            Flow5_GB.TabIndex = 37;
-            Flow5_GB.TabStop = false;
-            Flow5_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow5_Title_Label
-            // 
-            Flow5_Title_Label.AutoSize = true;
-            Flow5_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow5_Title_Label.Location = new Point(18, 0);
-            Flow5_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_Title_Label.Name = "Flow5_Title_Label";
-            Flow5_Title_Label.Size = new Size(156, 24);
-            Flow5_Title_Label.TabIndex = 35;
-            Flow5_Title_Label.Text = "Расходомер №5";
-            // 
-            // Flow5_CB
-            // 
-            Flow5_CB.AutoSize = true;
-            Flow5_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow5_CB.Location = new Point(228, 0);
-            Flow5_CB.Margin = new Padding(4);
-            Flow5_CB.Name = "Flow5_CB";
-            Flow5_CB.Size = new Size(97, 17);
-            Flow5_CB.TabIndex = 48;
-            Flow5_CB.Text = "Установлен";
-            Flow5_CB.UseVisualStyleBackColor = true;
-            Flow5_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow5_Manufacturer_CB
-            //
-            Flow5_Manufacturer_CB.AllowDrop = true;
-            Flow5_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow5_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow5_Manufacturer_CB.FormattingEnabled = true;
-            Flow5_Manufacturer_CB.IntegralHeight = false;
-            Flow5_Manufacturer_CB.Location = new Point(168, 67);
-            Flow5_Manufacturer_CB.Margin = new Padding(4);
-            Flow5_Manufacturer_CB.Name = "Flow5_Manufacturer_CB";
-            Flow5_Manufacturer_CB.Size = new Size(155, 23);
-            Flow5_Manufacturer_CB.TabIndex = 22;
-            Flow5_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow5_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow5_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow5_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow5_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow5_ManufactureDate_DTP
-            //
-            Flow5_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow5_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow5_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow5_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow5_ManufactureDate_DTP.Name = "Flow5_ManufactureDate_DTP";
-            Flow5_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow5_ManufactureDate_DTP.TabIndex = 24;
-            Flow5_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow5_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow5_ManufactureDate_Label
-            //
-            Flow5_ManufactureDate_Label.AutoSize = true;
-            Flow5_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow5_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_ManufactureDate_Label.Name = "Flow5_ManufactureDate_Label";
-            Flow5_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow5_ManufactureDate_Label.TabIndex = 24;
-            Flow5_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // Flow5_Manufacturer_Label
-            //
-            Flow5_Manufacturer_Label.AutoSize = true;
-            Flow5_Manufacturer_Label.Location = new Point(18, 70);
-            Flow5_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_Manufacturer_Label.Name = "Flow5_Manufacturer_Label";
-            Flow5_Manufacturer_Label.Size = new Size(92, 15);
-            Flow5_Manufacturer_Label.TabIndex = 23;
-            Flow5_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow5_Type_CB
-            //
-            Flow5_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow5_Type_CB.Location = new Point(168, 38);
-            Flow5_Type_CB.Margin = new Padding(4);
-            Flow5_Type_CB.Name = "Flow5_Type_CB";
-            Flow5_Type_CB.Size = new Size(155, 23);
-            Flow5_Type_CB.TabIndex = 20;
-            Flow5_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow5_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow5_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow5_Type_CB.Click += MeterTypeCB_Click;
-            Flow5_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow5_Type_Label
-            //
-            Flow5_Type_Label.AutoSize = true;
-            Flow5_Type_Label.Location = new Point(18, 40);
-            Flow5_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_Type_Label.Name = "Flow5_Type_Label";
-            Flow5_Type_Label.Size = new Size(28, 15);
-            Flow5_Type_Label.TabIndex = 21;
-            Flow5_Type_Label.Text = "Тип";
-            // 
-            // Flow5_Modification_CB
-            //
-            Flow5_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow5_Modification_CB.FormattingEnabled = true;
-            Flow5_Modification_CB.Location = new Point(168, 126);
-            Flow5_Modification_CB.Margin = new Padding(4);
-            Flow5_Modification_CB.Name = "Flow5_Modification_CB";
-            Flow5_Modification_CB.Size = new Size(155, 23);
-            Flow5_Modification_CB.TabIndex = 24;
-            Flow5_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow5_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow5_Modification_CB.Click += ModificationCB_Click;
-            Flow5_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow5_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            //
-            // Flow5_Modification_Label
-            // 
-            Flow5_Modification_Label.AutoSize = true;
-            Flow5_Modification_Label.Location = new Point(18, 130);
-            Flow5_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_Modification_Label.Name = "Flow5_Modification_Label";
-            Flow5_Modification_Label.Size = new Size(86, 15);
-            Flow5_Modification_Label.TabIndex = 25;
-            Flow5_Modification_Label.Text = "Модификация";
-            // 
-            // Flow5_ZavodskNomer_TB
-            //
-            Flow5_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow5_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow5_ZavodskNomer_TB.Name = "Flow5_ZavodskNomer_TB";
-            Flow5_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow5_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow5_RegistrationNumber_TB
-            //
-            Flow5_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow5_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow5_RegistrationNumber_TB.Name = "Flow5_RegistrationNumber_TB";
-            Flow5_RegistrationNumber_TB.ReadOnly = true;
-            Flow5_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow5_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow5_RegistrationNumber_Label
-            //
-            Flow5_RegistrationNumber_Label.AutoSize = true;
-            Flow5_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow5_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_RegistrationNumber_Label.Name = "Flow5_RegistrationNumber_Label";
-            Flow5_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow5_RegistrationNumber_Label.TabIndex = 26;
-            Flow5_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow5_ZavodskNomer_Label
-            //
-            Flow5_ZavodskNomer_Label.AutoSize = true;
-            Flow5_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow5_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow5_ZavodskNomer_Label.Name = "Flow5_ZavodskNomer_Label";
-            Flow5_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow5_ZavodskNomer_Label.TabIndex = 29;
-            Flow5_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Flow6_GB
-            // 
-            Flow6_GB.Controls.Add(Flow6_Title_Label);
-            Flow6_GB.Controls.Add(Flow6_CB);
-            Flow6_GB.Controls.Add(Flow6_Manufacturer_CB);
-            Flow6_GB.Controls.Add(Flow6_ManufactureDate_DTP);
-            Flow6_GB.Controls.Add(Flow6_ManufactureDate_Label);
-            Flow6_GB.Controls.Add(Flow6_Manufacturer_Label);
-            Flow6_GB.Controls.Add(Flow6_Type_CB);
-            Flow6_GB.Controls.Add(Flow6_Type_Label);
-            Flow6_GB.Controls.Add(Flow6_Modification_CB);
-            Flow6_GB.Controls.Add(Flow6_Modification_Label);
-            Flow6_GB.Controls.Add(Flow6_RegistrationNumber_TB);
-            Flow6_GB.Controls.Add(Flow6_RegistrationNumber_Label);
-            Flow6_GB.Controls.Add(Flow6_ZavodskNomer_TB);
-            Flow6_GB.Controls.Add(Flow6_ZavodskNomer_Label);
-            Flow6_GB.Location = new Point(757, 346);
-            Flow6_GB.Margin = new Padding(4);
-            Flow6_GB.Name = "Flow6_GB";
-            Flow6_GB.Padding = new Padding(4);
-            Flow6_GB.Size = new Size(342, 281);
-            Flow6_GB.TabIndex = 37;
-            Flow6_GB.TabStop = false;
-            Flow6_GB.Tag = "FirstFlowmeter";
-            // 
-            // Flow6_Title_Label
-            // 
-            Flow6_Title_Label.AutoSize = true;
-            Flow6_Title_Label.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
-            Flow6_Title_Label.Location = new Point(18, 0);
-            Flow6_Title_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_Title_Label.Name = "Flow6_Title_Label";
-            Flow6_Title_Label.Size = new Size(156, 24);
-            Flow6_Title_Label.TabIndex = 35;
-            Flow6_Title_Label.Text = "Расходомер №6";
-            // 
-            // Flow6_CB
-            // 
-            Flow6_CB.AutoSize = true;
-            Flow6_CB.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
-            Flow6_CB.Location = new Point(228, 0);
-            Flow6_CB.Margin = new Padding(4);
-            Flow6_CB.Name = "Flow6_CB";
-            Flow6_CB.Size = new Size(97, 17);
-            Flow6_CB.TabIndex = 49;
-            Flow6_CB.Text = "Установлен";
-            Flow6_CB.UseVisualStyleBackColor = true;
-            Flow6_CB.CheckedChanged += FlowCB_CheckedChanged;
-            // 
-            // Flow6_Manufacturer_CB
-            //
-            Flow6_Manufacturer_CB.AllowDrop = true;
-            Flow6_Manufacturer_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow6_Manufacturer_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow6_Manufacturer_CB.FormattingEnabled = true;
-            Flow6_Manufacturer_CB.IntegralHeight = false;
-            Flow6_Manufacturer_CB.Location = new Point(168, 67);
-            Flow6_Manufacturer_CB.Margin = new Padding(4);
-            Flow6_Manufacturer_CB.Name = "Flow6_Manufacturer_CB";
-            Flow6_Manufacturer_CB.Size = new Size(155, 23);
-            Flow6_Manufacturer_CB.TabIndex = 22;
-            Flow6_Manufacturer_CB.SelectedIndexChanged += ManufacturerCB_SelectedIndexChanged;
-            Flow6_Manufacturer_CB.Click += ManufacturerCB_Click;
-            Flow6_Manufacturer_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow6_Manufacturer_CB.KeyUp += ManufacturerCB_KeyUp;
-            Flow6_Manufacturer_CB.DropDownClosed += RestoreComboText;
-            //
-            // Flow6_ManufactureDate_DTP
-            //
-            Flow6_ManufactureDate_DTP.Location = new Point(168, 96);
-            Flow6_ManufactureDate_DTP.Margin = new Padding(3, 2, 3, 2);
-            Flow6_ManufactureDate_DTP.CustomFormat = "dd.MM.yyyy";
-            Flow6_ManufactureDate_DTP.Format = DateTimePickerFormat.Custom;
-            Flow6_ManufactureDate_DTP.Name = "Flow6_ManufactureDate_DTP";
-            Flow6_ManufactureDate_DTP.Size = new Size(155, 23);
-            Flow6_ManufactureDate_DTP.TabIndex = 24;
-            Flow6_ManufactureDate_DTP.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
-            Flow6_ManufactureDate_DTP.ValueChanged += ManufactureDateDTP_ValueChanged;
-            //
-            // Flow6_ManufactureDate_Label
-            //
-            Flow6_ManufactureDate_Label.AutoSize = true;
-            Flow6_ManufactureDate_Label.Location = new Point(18, 100);
-            Flow6_ManufactureDate_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_ManufactureDate_Label.Name = "Flow6_ManufactureDate_Label";
-            Flow6_ManufactureDate_Label.Size = new Size(111, 15);
-            Flow6_ManufactureDate_Label.TabIndex = 24;
-            Flow6_ManufactureDate_Label.Text = "Дата изготовления";
-            //
-            // Flow6_Manufacturer_Label
-            //
-            Flow6_Manufacturer_Label.AutoSize = true;
-            Flow6_Manufacturer_Label.Location = new Point(18, 70);
-            Flow6_Manufacturer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_Manufacturer_Label.Name = "Flow6_Manufacturer_Label";
-            Flow6_Manufacturer_Label.Size = new Size(92, 15);
-            Flow6_Manufacturer_Label.TabIndex = 23;
-            Flow6_Manufacturer_Label.Text = "Производитель";
-            // 
-            // Flow6_Type_CB
-            //
-            Flow6_Type_CB.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Flow6_Type_CB.Location = new Point(168, 38);
-            Flow6_Type_CB.Margin = new Padding(4);
-            Flow6_Type_CB.Name = "Flow6_Type_CB";
-            Flow6_Type_CB.Size = new Size(155, 23);
-            Flow6_Type_CB.TabIndex = 20;
-            Flow6_Type_CB.SelectedIndexChanged += TypeCB_SelectedIndexChanged;
-            Flow6_Type_CB.KeyDown += MeterTypeCB_KeyDown;
-            Flow6_Type_CB.KeyUp += MeterTypeCB_KeyUp;
-            Flow6_Type_CB.Click += MeterTypeCB_Click;
-            Flow6_Type_CB.DropDownClosed += RestoreComboText;
-            // 
-            // Flow6_Type_Label
-            //
-            Flow6_Type_Label.AutoSize = true;
-            Flow6_Type_Label.Location = new Point(18, 40);
-            Flow6_Type_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_Type_Label.Name = "Flow6_Type_Label";
-            Flow6_Type_Label.Size = new Size(28, 15);
-            Flow6_Type_Label.TabIndex = 21;
-            Flow6_Type_Label.Text = "Тип";
-            // 
-            // Flow6_Modification_CB
-            //
-            Flow6_Modification_CB.DropDownStyle = ComboBoxStyle.DropDown;
-            Flow6_Modification_CB.FormattingEnabled = true;
-            Flow6_Modification_CB.Location = new Point(168, 126);
-            Flow6_Modification_CB.Margin = new Padding(4);
-            Flow6_Modification_CB.Name = "Flow6_Modification_CB";
-            Flow6_Modification_CB.Size = new Size(155, 23);
-            Flow6_Modification_CB.TabIndex = 24;
-            Flow6_Modification_CB.TextUpdate += ModificationCB_TextUpdate;
-            Flow6_Modification_CB.KeyDown += ModificationCB_KeyDown;
-            Flow6_Modification_CB.Click += ModificationCB_Click;
-            Flow6_Modification_CB.DropDownClosed += RestoreComboText;
-            Flow6_Modification_CB.SelectedIndexChanged += ModificationCB_SelectedIndexChanged;
-            // 
-            // Flow6_Modification_Label
-            // 
-            Flow6_Modification_Label.AutoSize = true;
-            Flow6_Modification_Label.Location = new Point(18, 130);
-            Flow6_Modification_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_Modification_Label.Name = "Flow6_Modification_Label";
-            Flow6_Modification_Label.Size = new Size(86, 15);
-            Flow6_Modification_Label.TabIndex = 25;
-            Flow6_Modification_Label.Text = "Модификация";
-            // 
-            // Flow6_ZavodskNomer_TB
-            //
-            Flow6_ZavodskNomer_TB.Location = new Point(168, 185);
-            Flow6_ZavodskNomer_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow6_ZavodskNomer_TB.Name = "Flow6_ZavodskNomer_TB";
-            Flow6_ZavodskNomer_TB.Size = new Size(155, 23);
-            Flow6_ZavodskNomer_TB.TabIndex = 28;
-            //
-            // Flow6_RegistrationNumber_TB
-            //
-            Flow6_RegistrationNumber_TB.Location = new Point(168, 155);
-            Flow6_RegistrationNumber_TB.Margin = new Padding(3, 2, 3, 2);
-            Flow6_RegistrationNumber_TB.Name = "Flow6_RegistrationNumber_TB";
-            Flow6_RegistrationNumber_TB.ReadOnly = true;
-            Flow6_RegistrationNumber_TB.Size = new Size(155, 23);
-            Flow6_RegistrationNumber_TB.TabIndex = 27;
-            //
-            // Flow6_RegistrationNumber_Label
-            //
-            Flow6_RegistrationNumber_Label.AutoSize = true;
-            Flow6_RegistrationNumber_Label.Location = new Point(18, 160);
-            Flow6_RegistrationNumber_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_RegistrationNumber_Label.Name = "Flow6_RegistrationNumber_Label";
-            Flow6_RegistrationNumber_Label.Size = new Size(134, 15);
-            Flow6_RegistrationNumber_Label.TabIndex = 26;
-            Flow6_RegistrationNumber_Label.Text = "Номер госреестра СИ";
-            //
-            // Flow6_ZavodskNomer_Label
-            //
-            Flow6_ZavodskNomer_Label.AutoSize = true;
-            Flow6_ZavodskNomer_Label.Location = new Point(18, 190);
-            Flow6_ZavodskNomer_Label.Margin = new Padding(4, 0, 4, 0);
-            Flow6_ZavodskNomer_Label.Name = "Flow6_ZavodskNomer_Label";
-            Flow6_ZavodskNomer_Label.Size = new Size(104, 15);
-            Flow6_ZavodskNomer_Label.TabIndex = 29;
-            Flow6_ZavodskNomer_Label.Text = "Заводской номер";
-            // 
-            // Next_B
-            // 
-            Next_B.Location = new Point(1012, 682);
-            Next_B.Margin = new Padding(4);
-            Next_B.Name = "Next_B";
-            Next_B.Size = new Size(88, 26);
-            Next_B.TabIndex = 42;
-            Next_B.Text = "Далее";
-            Next_B.UseVisualStyleBackColor = true;
-            //
-            // button1
-            //
-            button1.Location = new Point(60, 682);
-            button1.Margin = new Padding(4);
-            button1.Name = "button1";
-            button1.Size = new Size(88, 26);
-            button1.TabIndex = 43;
-            button1.Text = "Выход";
-            button1.UseVisualStyleBackColor = true;
+            // Flow1FactoryNumberTextBox
+            //
+            Flow1FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow1FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow1FactoryNumberTextBox.Name = "Flow1FactoryNumberTextBox";
+            Flow1FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow1FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow1RegistrationNumberTextBox
+            //
+            Flow1RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow1RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow1RegistrationNumberTextBox.Name = "Flow1RegistrationNumberTextBox";
+            Flow1RegistrationNumberTextBox.ReadOnly = true;
+            Flow1RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow1RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow1RegistrationNumberLabel
+            //
+            Flow1RegistrationNumberLabel.AutoSize = true;
+            Flow1RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow1RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1RegistrationNumberLabel.Name = "Flow1RegistrationNumberLabel";
+            Flow1RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow1RegistrationNumberLabel.TabIndex = 26;
+            Flow1RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow1FactoryNumberLabel
+            //
+            Flow1FactoryNumberLabel.AutoSize = true;
+            Flow1FactoryNumberLabel.Location = new Point(18, 190);
+            Flow1FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1FactoryNumberLabel.Name = "Flow1FactoryNumberLabel";
+            Flow1FactoryNumberLabel.Size = new Size(104, 15);
+            Flow1FactoryNumberLabel.TabIndex = 29;
+            Flow1FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // Flow1ModificationLabel
+            // 
+            Flow1ModificationLabel.AutoSize = true;
+            Flow1ModificationLabel.Location = new Point(18, 130);
+            Flow1ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1ModificationLabel.Name = "Flow1ModificationLabel";
+            Flow1ModificationLabel.Size = new Size(86, 15);
+            Flow1ModificationLabel.TabIndex = 25;
+            Flow1ModificationLabel.Text = "Модификация";
+            //
+            // Flow1ModificationComboBox
+            //
+            Flow1ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow1ModificationComboBox.FormattingEnabled = true;
+            Flow1ModificationComboBox.Location = new Point(168, 126);
+            Flow1ModificationComboBox.Margin = new Padding(4);
+            Flow1ModificationComboBox.Name = "Flow1ModificationComboBox";
+            Flow1ModificationComboBox.Size = new Size(155, 23);
+            Flow1ModificationComboBox.TabIndex = 24;
+            Flow1ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow1ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow1ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow1ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow1ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            //
+            // Flow1TypeLabel
+            //
+            Flow1TypeLabel.AutoSize = true;
+            Flow1TypeLabel.Location = new Point(18, 40);
+            Flow1TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1TypeLabel.Name = "Flow1TypeLabel";
+            Flow1TypeLabel.Size = new Size(28, 15);
+            Flow1TypeLabel.TabIndex = 21;
+            Flow1TypeLabel.Text = "Тип";
+            // 
+            // Flow1TypeComboBox
+            // 
+            Flow1TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1TypeComboBox.Location = new Point(168, 38);
+            Flow1TypeComboBox.Margin = new Padding(4);
+            Flow1TypeComboBox.Name = "Flow1TypeComboBox";
+            Flow1TypeComboBox.Size = new Size(155, 23);
+            Flow1TypeComboBox.TabIndex = 20;
+            Flow1TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow1TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow1TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow1TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow1TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow1ManufacturerLabel
+            // 
+            Flow1ManufacturerLabel.AutoSize = true;
+            Flow1ManufacturerLabel.Location = new Point(18, 70);
+            Flow1ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1ManufacturerLabel.Name = "Flow1ManufacturerLabel";
+            Flow1ManufacturerLabel.Size = new Size(92, 15);
+            Flow1ManufacturerLabel.TabIndex = 23;
+            Flow1ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow1ManufacturerComboBox
+            // 
+            Flow1ManufacturerComboBox.AllowDrop = true;
+            Flow1ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow1ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow1ManufacturerComboBox.FormattingEnabled = true;
+            Flow1ManufacturerComboBox.IntegralHeight = false;
+            Flow1ManufacturerComboBox.Location = new Point(168, 67);
+            Flow1ManufacturerComboBox.Margin = new Padding(4);
+            Flow1ManufacturerComboBox.Name = "Flow1ManufacturerComboBox";
+            Flow1ManufacturerComboBox.Size = new Size(155, 23);
+            Flow1ManufacturerComboBox.TabIndex = 22;
+            Flow1ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow1ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow1ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow1ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow1ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow1ManufactureDateDateTimePicker
+            //
+            Flow1ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow1ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow1ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow1ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow1ManufactureDateDateTimePicker.Name = "Flow1ManufactureDateDateTimePicker";
+            Flow1ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow1ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow1ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow1ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow1ManufactureDateLabel
+            //
+            Flow1ManufactureDateLabel.AutoSize = true;
+            Flow1ManufactureDateLabel.Location = new Point(18, 100);
+            Flow1ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1ManufactureDateLabel.Name = "Flow1ManufactureDateLabel";
+            Flow1ManufactureDateLabel.Size = new Size(111, 15);
+            Flow1ManufactureDateLabel.TabIndex = 24;
+            Flow1ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // HeaderLabel
+            //
+            HeaderLabel.AutoSize = true;
+            HeaderLabel.Font = new Font("Microsoft Sans Serif", 20F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            HeaderLabel.Location = new Point(192, 22);
+            HeaderLabel.Margin = new Padding(4, 0, 4, 0);
+            HeaderLabel.Name = "HeaderLabel";
+            HeaderLabel.Size = new Size(710, 31);
+            HeaderLabel.TabIndex = 19;
+            HeaderLabel.Text = "Настройка параметров поверяемых преобразователей";
+            // 
+            // Flow1GroupBox
+            // 
+            Flow1GroupBox.Controls.Add(Flow1TitleLabel);
+            Flow1GroupBox.Controls.Add(Flow1CheckBox);
+            Flow1GroupBox.Controls.Add(Flow1ManufacturerComboBox);
+            Flow1GroupBox.Controls.Add(Flow1ManufactureDateDateTimePicker);
+            Flow1GroupBox.Controls.Add(Flow1ManufactureDateLabel);
+            Flow1GroupBox.Controls.Add(Flow1ManufacturerLabel);
+            Flow1GroupBox.Controls.Add(Flow1TypeComboBox);
+            Flow1GroupBox.Controls.Add(Flow1TypeLabel);
+            Flow1GroupBox.Controls.Add(Flow1ModificationComboBox);
+            Flow1GroupBox.Controls.Add(Flow1ModificationLabel);
+            Flow1GroupBox.Controls.Add(Flow1RegistrationNumberTextBox);
+            Flow1GroupBox.Controls.Add(Flow1RegistrationNumberLabel);
+            Flow1GroupBox.Controls.Add(Flow1FactoryNumberTextBox);
+            Flow1GroupBox.Controls.Add(Flow1FactoryNumberLabel);
+            Flow1GroupBox.Location = new Point(60, 56);
+            Flow1GroupBox.Margin = new Padding(4);
+            Flow1GroupBox.Name = "Flow1GroupBox";
+            Flow1GroupBox.Padding = new Padding(4);
+            Flow1GroupBox.Size = new Size(342, 281);
+            Flow1GroupBox.TabIndex = 34;
+            Flow1GroupBox.TabStop = false;
+            Flow1GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow1TitleLabel
+            // 
+            Flow1TitleLabel.AutoSize = true;
+            Flow1TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow1TitleLabel.Location = new Point(18, 0);
+            Flow1TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow1TitleLabel.Name = "Flow1TitleLabel";
+            Flow1TitleLabel.Size = new Size(156, 24);
+            Flow1TitleLabel.TabIndex = 35;
+            Flow1TitleLabel.Text = "Расходомер №1";
+            // 
+            // Flow1CheckBox
+            // 
+            Flow1CheckBox.AutoSize = true;
+            Flow1CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow1CheckBox.Location = new Point(228, 0);
+            Flow1CheckBox.Margin = new Padding(4);
+            Flow1CheckBox.Name = "Flow1CheckBox";
+            Flow1CheckBox.Size = new Size(97, 17);
+            Flow1CheckBox.TabIndex = 36;
+            Flow1CheckBox.Text = "Установлен";
+            Flow1CheckBox.UseVisualStyleBackColor = true;
+            Flow1CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow2GroupBox
+            // 
+            Flow2GroupBox.Controls.Add(Flow2TitleLabel);
+            Flow2GroupBox.Controls.Add(Flow2CheckBox);
+            Flow2GroupBox.Controls.Add(Flow2ManufacturerComboBox);
+            Flow2GroupBox.Controls.Add(Flow2ManufactureDateDateTimePicker);
+            Flow2GroupBox.Controls.Add(Flow2ManufactureDateLabel);
+            Flow2GroupBox.Controls.Add(Flow2ManufacturerLabel);
+            Flow2GroupBox.Controls.Add(Flow2TypeComboBox);
+            Flow2GroupBox.Controls.Add(Flow2TypeLabel);
+            Flow2GroupBox.Controls.Add(Flow2ModificationComboBox);
+            Flow2GroupBox.Controls.Add(Flow2ModificationLabel);
+            Flow2GroupBox.Controls.Add(Flow2RegistrationNumberTextBox);
+            Flow2GroupBox.Controls.Add(Flow2RegistrationNumberLabel);
+            Flow2GroupBox.Controls.Add(Flow2FactoryNumberTextBox);
+            Flow2GroupBox.Controls.Add(Flow2FactoryNumberLabel);
+            Flow2GroupBox.Location = new Point(60, 346);
+            Flow2GroupBox.Margin = new Padding(4);
+            Flow2GroupBox.Name = "Flow2GroupBox";
+            Flow2GroupBox.Padding = new Padding(4);
+            Flow2GroupBox.Size = new Size(342, 281);
+            Flow2GroupBox.TabIndex = 36;
+            Flow2GroupBox.TabStop = false;
+            Flow2GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow2TitleLabel
+            // 
+            Flow2TitleLabel.AutoSize = true;
+            Flow2TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow2TitleLabel.Location = new Point(18, 0);
+            Flow2TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2TitleLabel.Name = "Flow2TitleLabel";
+            Flow2TitleLabel.Size = new Size(156, 24);
+            Flow2TitleLabel.TabIndex = 35;
+            Flow2TitleLabel.Text = "Расходомер №2";
+            // 
+            // Flow2CheckBox
+            // 
+            Flow2CheckBox.AutoSize = true;
+            Flow2CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow2CheckBox.Location = new Point(228, 0);
+            Flow2CheckBox.Margin = new Padding(4);
+            Flow2CheckBox.Name = "Flow2CheckBox";
+            Flow2CheckBox.Size = new Size(97, 17);
+            Flow2CheckBox.TabIndex = 45;
+            Flow2CheckBox.Text = "Установлен";
+            Flow2CheckBox.UseVisualStyleBackColor = true;
+            Flow2CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow2ManufacturerComboBox
+            //
+            Flow2ManufacturerComboBox.AllowDrop = true;
+            Flow2ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow2ManufacturerComboBox.FormattingEnabled = true;
+            Flow2ManufacturerComboBox.IntegralHeight = false;
+            Flow2ManufacturerComboBox.Location = new Point(168, 67);
+            Flow2ManufacturerComboBox.Margin = new Padding(4);
+            Flow2ManufacturerComboBox.Name = "Flow2ManufacturerComboBox";
+            Flow2ManufacturerComboBox.Size = new Size(155, 23);
+            Flow2ManufacturerComboBox.TabIndex = 22;
+            Flow2ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow2ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow2ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow2ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow2ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow2ManufactureDateDateTimePicker
+            //
+            Flow2ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow2ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow2ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow2ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow2ManufactureDateDateTimePicker.Name = "Flow2ManufactureDateDateTimePicker";
+            Flow2ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow2ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow2ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow2ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow2ManufactureDateLabel
+            //
+            Flow2ManufactureDateLabel.AutoSize = true;
+            Flow2ManufactureDateLabel.Location = new Point(18, 100);
+            Flow2ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2ManufactureDateLabel.Name = "Flow2ManufactureDateLabel";
+            Flow2ManufactureDateLabel.Size = new Size(111, 15);
+            Flow2ManufactureDateLabel.TabIndex = 24;
+            Flow2ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // Flow2ManufacturerLabel
+            //
+            Flow2ManufacturerLabel.AutoSize = true;
+            Flow2ManufacturerLabel.Location = new Point(18, 70);
+            Flow2ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2ManufacturerLabel.Name = "Flow2ManufacturerLabel";
+            Flow2ManufacturerLabel.Size = new Size(92, 15);
+            Flow2ManufacturerLabel.TabIndex = 23;
+            Flow2ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow2TypeComboBox
+            //
+            Flow2TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow2TypeComboBox.Location = new Point(168, 38);
+            Flow2TypeComboBox.Margin = new Padding(4);
+            Flow2TypeComboBox.Name = "Flow2TypeComboBox";
+            Flow2TypeComboBox.Size = new Size(155, 23);
+            Flow2TypeComboBox.TabIndex = 20;
+            Flow2TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow2TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow2TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow2TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow2TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow2TypeLabel
+            //
+            Flow2TypeLabel.AutoSize = true;
+            Flow2TypeLabel.Location = new Point(18, 40);
+            Flow2TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2TypeLabel.Name = "Flow2TypeLabel";
+            Flow2TypeLabel.Size = new Size(28, 15);
+            Flow2TypeLabel.TabIndex = 21;
+            Flow2TypeLabel.Text = "Тип";
+            //
+            // Flow2ModificationComboBox
+            //
+            Flow2ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow2ModificationComboBox.FormattingEnabled = true;
+            Flow2ModificationComboBox.Location = new Point(168, 126);
+            Flow2ModificationComboBox.Margin = new Padding(4);
+            Flow2ModificationComboBox.Name = "Flow2ModificationComboBox";
+            Flow2ModificationComboBox.Size = new Size(155, 23);
+            Flow2ModificationComboBox.TabIndex = 24;
+            Flow2ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow2ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow2ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow2ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow2ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            //
+            // Flow2ModificationLabel
+            // 
+            Flow2ModificationLabel.AutoSize = true;
+            Flow2ModificationLabel.Location = new Point(18, 130);
+            Flow2ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2ModificationLabel.Name = "Flow2ModificationLabel";
+            Flow2ModificationLabel.Size = new Size(86, 15);
+            Flow2ModificationLabel.TabIndex = 25;
+            Flow2ModificationLabel.Text = "Модификация";
+            // 
+            // Flow2FactoryNumberTextBox
+            //
+            Flow2FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow2FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow2FactoryNumberTextBox.Name = "Flow2FactoryNumberTextBox";
+            Flow2FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow2FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow2RegistrationNumberTextBox
+            //
+            Flow2RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow2RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow2RegistrationNumberTextBox.Name = "Flow2RegistrationNumberTextBox";
+            Flow2RegistrationNumberTextBox.ReadOnly = true;
+            Flow2RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow2RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow2RegistrationNumberLabel
+            //
+            Flow2RegistrationNumberLabel.AutoSize = true;
+            Flow2RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow2RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2RegistrationNumberLabel.Name = "Flow2RegistrationNumberLabel";
+            Flow2RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow2RegistrationNumberLabel.TabIndex = 26;
+            Flow2RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow2FactoryNumberLabel
+            //
+            Flow2FactoryNumberLabel.AutoSize = true;
+            Flow2FactoryNumberLabel.Location = new Point(18, 190);
+            Flow2FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow2FactoryNumberLabel.Name = "Flow2FactoryNumberLabel";
+            Flow2FactoryNumberLabel.Size = new Size(104, 15);
+            Flow2FactoryNumberLabel.TabIndex = 29;
+            Flow2FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // Flow3GroupBox
+            // 
+            Flow3GroupBox.Controls.Add(Flow3TitleLabel);
+            Flow3GroupBox.Controls.Add(Flow3CheckBox);
+            Flow3GroupBox.Controls.Add(Flow3ManufacturerComboBox);
+            Flow3GroupBox.Controls.Add(Flow3ManufactureDateDateTimePicker);
+            Flow3GroupBox.Controls.Add(Flow3ManufactureDateLabel);
+            Flow3GroupBox.Controls.Add(Flow3ManufacturerLabel);
+            Flow3GroupBox.Controls.Add(Flow3TypeComboBox);
+            Flow3GroupBox.Controls.Add(Flow3TypeLabel);
+            Flow3GroupBox.Controls.Add(Flow3ModificationComboBox);
+            Flow3GroupBox.Controls.Add(Flow3ModificationLabel);
+            Flow3GroupBox.Controls.Add(Flow3RegistrationNumberTextBox);
+            Flow3GroupBox.Controls.Add(Flow3RegistrationNumberLabel);
+            Flow3GroupBox.Controls.Add(Flow3FactoryNumberTextBox);
+            Flow3GroupBox.Controls.Add(Flow3FactoryNumberLabel);
+            Flow3GroupBox.Location = new Point(409, 56);
+            Flow3GroupBox.Margin = new Padding(4);
+            Flow3GroupBox.Name = "Flow3GroupBox";
+            Flow3GroupBox.Padding = new Padding(4);
+            Flow3GroupBox.Size = new Size(342, 281);
+            Flow3GroupBox.TabIndex = 37;
+            Flow3GroupBox.TabStop = false;
+            Flow3GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow3TitleLabel
+            // 
+            Flow3TitleLabel.AutoSize = true;
+            Flow3TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow3TitleLabel.Location = new Point(18, 0);
+            Flow3TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3TitleLabel.Name = "Flow3TitleLabel";
+            Flow3TitleLabel.Size = new Size(156, 24);
+            Flow3TitleLabel.TabIndex = 35;
+            Flow3TitleLabel.Text = "Расходомер №3";
+            // 
+            // Flow3CheckBox
+            // 
+            Flow3CheckBox.AutoSize = true;
+            Flow3CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow3CheckBox.Location = new Point(228, 0);
+            Flow3CheckBox.Margin = new Padding(4);
+            Flow3CheckBox.Name = "Flow3CheckBox";
+            Flow3CheckBox.Size = new Size(97, 17);
+            Flow3CheckBox.TabIndex = 46;
+            Flow3CheckBox.Text = "Установлен";
+            Flow3CheckBox.UseVisualStyleBackColor = true;
+            Flow3CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow3ManufacturerComboBox
+            //
+            Flow3ManufacturerComboBox.AllowDrop = true;
+            Flow3ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow3ManufacturerComboBox.FormattingEnabled = true;
+            Flow3ManufacturerComboBox.IntegralHeight = false;
+            Flow3ManufacturerComboBox.Location = new Point(168, 67);
+            Flow3ManufacturerComboBox.Margin = new Padding(4);
+            Flow3ManufacturerComboBox.Name = "Flow3ManufacturerComboBox";
+            Flow3ManufacturerComboBox.Size = new Size(155, 23);
+            Flow3ManufacturerComboBox.TabIndex = 22;
+            Flow3ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow3ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow3ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow3ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow3ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow3ManufactureDateDateTimePicker
+            //
+            Flow3ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow3ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow3ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow3ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow3ManufactureDateDateTimePicker.Name = "Flow3ManufactureDateDateTimePicker";
+            Flow3ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow3ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow3ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow3ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow3ManufactureDateLabel
+            //
+            Flow3ManufactureDateLabel.AutoSize = true;
+            Flow3ManufactureDateLabel.Location = new Point(18, 100);
+            Flow3ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3ManufactureDateLabel.Name = "Flow3ManufactureDateLabel";
+            Flow3ManufactureDateLabel.Size = new Size(111, 15);
+            Flow3ManufactureDateLabel.TabIndex = 24;
+            Flow3ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // Flow3ManufacturerLabel
+            //
+            Flow3ManufacturerLabel.AutoSize = true;
+            Flow3ManufacturerLabel.Location = new Point(18, 70);
+            Flow3ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3ManufacturerLabel.Name = "Flow3ManufacturerLabel";
+            Flow3ManufacturerLabel.Size = new Size(92, 15);
+            Flow3ManufacturerLabel.TabIndex = 23;
+            Flow3ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow3TypeComboBox
+            //
+            Flow3TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow3TypeComboBox.Location = new Point(168, 38);
+            Flow3TypeComboBox.Margin = new Padding(4);
+            Flow3TypeComboBox.Name = "Flow3TypeComboBox";
+            Flow3TypeComboBox.Size = new Size(155, 23);
+            Flow3TypeComboBox.TabIndex = 20;
+            Flow3TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow3TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow3TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow3TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow3TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow3TypeLabel
+            //
+            Flow3TypeLabel.AutoSize = true;
+            Flow3TypeLabel.Location = new Point(18, 40);
+            Flow3TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3TypeLabel.Name = "Flow3TypeLabel";
+            Flow3TypeLabel.Size = new Size(28, 15);
+            Flow3TypeLabel.TabIndex = 21;
+            Flow3TypeLabel.Text = "Тип";
+            // 
+            // Flow3ModificationComboBox
+            //
+            Flow3ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow3ModificationComboBox.FormattingEnabled = true;
+            Flow3ModificationComboBox.Location = new Point(168, 126);
+            Flow3ModificationComboBox.Margin = new Padding(4);
+            Flow3ModificationComboBox.Name = "Flow3ModificationComboBox";
+            Flow3ModificationComboBox.Size = new Size(155, 23);
+            Flow3ModificationComboBox.TabIndex = 24;
+            Flow3ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow3ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow3ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow3ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow3ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            //
+            // Flow3ModificationLabel
+            // 
+            Flow3ModificationLabel.AutoSize = true;
+            Flow3ModificationLabel.Location = new Point(18, 130);
+            Flow3ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3ModificationLabel.Name = "Flow3ModificationLabel";
+            Flow3ModificationLabel.Size = new Size(86, 15);
+            Flow3ModificationLabel.TabIndex = 25;
+            Flow3ModificationLabel.Text = "Модификация";
+            // 
+            // Flow3FactoryNumberTextBox
+            //
+            Flow3FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow3FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow3FactoryNumberTextBox.Name = "Flow3FactoryNumberTextBox";
+            Flow3FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow3FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow3RegistrationNumberTextBox
+            //
+            Flow3RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow3RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow3RegistrationNumberTextBox.Name = "Flow3RegistrationNumberTextBox";
+            Flow3RegistrationNumberTextBox.ReadOnly = true;
+            Flow3RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow3RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow3RegistrationNumberLabel
+            //
+            Flow3RegistrationNumberLabel.AutoSize = true;
+            Flow3RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow3RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3RegistrationNumberLabel.Name = "Flow3RegistrationNumberLabel";
+            Flow3RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow3RegistrationNumberLabel.TabIndex = 26;
+            Flow3RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow3FactoryNumberLabel
+            //
+            Flow3FactoryNumberLabel.AutoSize = true;
+            Flow3FactoryNumberLabel.Location = new Point(18, 190);
+            Flow3FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow3FactoryNumberLabel.Name = "Flow3FactoryNumberLabel";
+            Flow3FactoryNumberLabel.Size = new Size(104, 15);
+            Flow3FactoryNumberLabel.TabIndex = 29;
+            Flow3FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // Flow4GroupBox
+            // 
+            Flow4GroupBox.Controls.Add(Flow4TitleLabel);
+            Flow4GroupBox.Controls.Add(Flow4CheckBox);
+            Flow4GroupBox.Controls.Add(Flow4ManufacturerComboBox);
+            Flow4GroupBox.Controls.Add(Flow4ManufactureDateDateTimePicker);
+            Flow4GroupBox.Controls.Add(Flow4ManufactureDateLabel);
+            Flow4GroupBox.Controls.Add(Flow4ManufacturerLabel);
+            Flow4GroupBox.Controls.Add(Flow4TypeComboBox);
+            Flow4GroupBox.Controls.Add(Flow4TypeLabel);
+            Flow4GroupBox.Controls.Add(Flow4ModificationComboBox);
+            Flow4GroupBox.Controls.Add(Flow4ModificationLabel);
+            Flow4GroupBox.Controls.Add(Flow4RegistrationNumberTextBox);
+            Flow4GroupBox.Controls.Add(Flow4RegistrationNumberLabel);
+            Flow4GroupBox.Controls.Add(Flow4FactoryNumberTextBox);
+            Flow4GroupBox.Controls.Add(Flow4FactoryNumberLabel);
+            Flow4GroupBox.Location = new Point(409, 346);
+            Flow4GroupBox.Margin = new Padding(4);
+            Flow4GroupBox.Name = "Flow4GroupBox";
+            Flow4GroupBox.Padding = new Padding(4);
+            Flow4GroupBox.Size = new Size(342, 281);
+            Flow4GroupBox.TabIndex = 38;
+            Flow4GroupBox.TabStop = false;
+            Flow4GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow4TitleLabel
+            // 
+            Flow4TitleLabel.AutoSize = true;
+            Flow4TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow4TitleLabel.Location = new Point(18, 0);
+            Flow4TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4TitleLabel.Name = "Flow4TitleLabel";
+            Flow4TitleLabel.Size = new Size(156, 24);
+            Flow4TitleLabel.TabIndex = 35;
+            Flow4TitleLabel.Text = "Расходомер №4";
+            // 
+            // Flow4CheckBox
+            // 
+            Flow4CheckBox.AutoSize = true;
+            Flow4CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow4CheckBox.Location = new Point(228, 0);
+            Flow4CheckBox.Margin = new Padding(4);
+            Flow4CheckBox.Name = "Flow4CheckBox";
+            Flow4CheckBox.Size = new Size(97, 17);
+            Flow4CheckBox.TabIndex = 47;
+            Flow4CheckBox.Text = "Установлен";
+            Flow4CheckBox.UseVisualStyleBackColor = true;
+            Flow4CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow4ManufacturerComboBox
+            //
+            Flow4ManufacturerComboBox.AllowDrop = true;
+            Flow4ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow4ManufacturerComboBox.FormattingEnabled = true;
+            Flow4ManufacturerComboBox.IntegralHeight = false;
+            Flow4ManufacturerComboBox.Location = new Point(168, 67);
+            Flow4ManufacturerComboBox.Margin = new Padding(4);
+            Flow4ManufacturerComboBox.Name = "Flow4ManufacturerComboBox";
+            Flow4ManufacturerComboBox.Size = new Size(155, 23);
+            Flow4ManufacturerComboBox.TabIndex = 22;
+            Flow4ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow4ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow4ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow4ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow4ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow4ManufactureDateDateTimePicker
+            //
+            Flow4ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow4ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow4ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow4ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow4ManufactureDateDateTimePicker.Name = "Flow4ManufactureDateDateTimePicker";
+            Flow4ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow4ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow4ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow4ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow4ManufactureDateLabel
+            //
+            Flow4ManufactureDateLabel.AutoSize = true;
+            Flow4ManufactureDateLabel.Location = new Point(18, 100);
+            Flow4ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4ManufactureDateLabel.Name = "Flow4ManufactureDateLabel";
+            Flow4ManufactureDateLabel.Size = new Size(111, 15);
+            Flow4ManufactureDateLabel.TabIndex = 24;
+            Flow4ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // Flow4ManufacturerLabel
+            //
+            Flow4ManufacturerLabel.AutoSize = true;
+            Flow4ManufacturerLabel.Location = new Point(18, 70);
+            Flow4ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4ManufacturerLabel.Name = "Flow4ManufacturerLabel";
+            Flow4ManufacturerLabel.Size = new Size(92, 15);
+            Flow4ManufacturerLabel.TabIndex = 23;
+            Flow4ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow4TypeComboBox
+            //
+            Flow4TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow4TypeComboBox.Location = new Point(168, 38);
+            Flow4TypeComboBox.Margin = new Padding(4);
+            Flow4TypeComboBox.Name = "Flow4TypeComboBox";
+            Flow4TypeComboBox.Size = new Size(155, 23);
+            Flow4TypeComboBox.TabIndex = 20;
+            Flow4TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow4TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow4TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow4TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow4TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow4TypeLabel
+            //
+            Flow4TypeLabel.AutoSize = true;
+            Flow4TypeLabel.Location = new Point(18, 40);
+            Flow4TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4TypeLabel.Name = "Flow4TypeLabel";
+            Flow4TypeLabel.Size = new Size(117, 15);
+            Flow4TypeLabel.TabIndex = 21;
+            Flow4TypeLabel.Text = "Тип";
+            // 
+            // Flow4ModificationComboBox
+            //
+            Flow4ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow4ModificationComboBox.FormattingEnabled = true;
+            Flow4ModificationComboBox.Location = new Point(168, 126);
+            Flow4ModificationComboBox.Margin = new Padding(4);
+            Flow4ModificationComboBox.Name = "Flow4ModificationComboBox";
+            Flow4ModificationComboBox.Size = new Size(155, 23);
+            Flow4ModificationComboBox.TabIndex = 24;
+            Flow4ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow4ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow4ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow4ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow4ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            //
+            // Flow4ModificationLabel
+            // 
+            Flow4ModificationLabel.AutoSize = true;
+            Flow4ModificationLabel.Location = new Point(18, 130);
+            Flow4ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4ModificationLabel.Name = "Flow4ModificationLabel";
+            Flow4ModificationLabel.Size = new Size(86, 15);
+            Flow4ModificationLabel.TabIndex = 25;
+            Flow4ModificationLabel.Text = "Модификация";
+            // 
+            // Flow4FactoryNumberTextBox
+            //
+            Flow4FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow4FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow4FactoryNumberTextBox.Name = "Flow4FactoryNumberTextBox";
+            Flow4FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow4FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow4RegistrationNumberTextBox
+            //
+            Flow4RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow4RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow4RegistrationNumberTextBox.Name = "Flow4RegistrationNumberTextBox";
+            Flow4RegistrationNumberTextBox.ReadOnly = true;
+            Flow4RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow4RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow4RegistrationNumberLabel
+            //
+            Flow4RegistrationNumberLabel.AutoSize = true;
+            Flow4RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow4RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4RegistrationNumberLabel.Name = "Flow4RegistrationNumberLabel";
+            Flow4RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow4RegistrationNumberLabel.TabIndex = 26;
+            Flow4RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow4FactoryNumberLabel
+            //
+            Flow4FactoryNumberLabel.AutoSize = true;
+            Flow4FactoryNumberLabel.Location = new Point(18, 190);
+            Flow4FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow4FactoryNumberLabel.Name = "Flow4FactoryNumberLabel";
+            Flow4FactoryNumberLabel.Size = new Size(104, 15);
+            Flow4FactoryNumberLabel.TabIndex = 29;
+            Flow4FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // Flow5GroupBox
+            // 
+            Flow5GroupBox.Controls.Add(Flow5TitleLabel);
+            Flow5GroupBox.Controls.Add(Flow5CheckBox);
+            Flow5GroupBox.Controls.Add(Flow5ManufacturerComboBox);
+            Flow5GroupBox.Controls.Add(Flow5ManufactureDateDateTimePicker);
+            Flow5GroupBox.Controls.Add(Flow5ManufactureDateLabel);
+            Flow5GroupBox.Controls.Add(Flow5ManufacturerLabel);
+            Flow5GroupBox.Controls.Add(Flow5TypeComboBox);
+            Flow5GroupBox.Controls.Add(Flow5TypeLabel);
+            Flow5GroupBox.Controls.Add(Flow5ModificationComboBox);
+            Flow5GroupBox.Controls.Add(Flow5ModificationLabel);
+            Flow5GroupBox.Controls.Add(Flow5RegistrationNumberTextBox);
+            Flow5GroupBox.Controls.Add(Flow5RegistrationNumberLabel);
+            Flow5GroupBox.Controls.Add(Flow5FactoryNumberTextBox);
+            Flow5GroupBox.Controls.Add(Flow5FactoryNumberLabel);
+            Flow5GroupBox.Location = new Point(757, 56);
+            Flow5GroupBox.Margin = new Padding(4);
+            Flow5GroupBox.Name = "Flow5GroupBox";
+            Flow5GroupBox.Padding = new Padding(4);
+            Flow5GroupBox.Size = new Size(342, 281);
+            Flow5GroupBox.TabIndex = 37;
+            Flow5GroupBox.TabStop = false;
+            Flow5GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow5TitleLabel
+            // 
+            Flow5TitleLabel.AutoSize = true;
+            Flow5TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow5TitleLabel.Location = new Point(18, 0);
+            Flow5TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5TitleLabel.Name = "Flow5TitleLabel";
+            Flow5TitleLabel.Size = new Size(156, 24);
+            Flow5TitleLabel.TabIndex = 35;
+            Flow5TitleLabel.Text = "Расходомер №5";
+            // 
+            // Flow5CheckBox
+            // 
+            Flow5CheckBox.AutoSize = true;
+            Flow5CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow5CheckBox.Location = new Point(228, 0);
+            Flow5CheckBox.Margin = new Padding(4);
+            Flow5CheckBox.Name = "Flow5CheckBox";
+            Flow5CheckBox.Size = new Size(97, 17);
+            Flow5CheckBox.TabIndex = 48;
+            Flow5CheckBox.Text = "Установлен";
+            Flow5CheckBox.UseVisualStyleBackColor = true;
+            Flow5CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow5ManufacturerComboBox
+            //
+            Flow5ManufacturerComboBox.AllowDrop = true;
+            Flow5ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow5ManufacturerComboBox.FormattingEnabled = true;
+            Flow5ManufacturerComboBox.IntegralHeight = false;
+            Flow5ManufacturerComboBox.Location = new Point(168, 67);
+            Flow5ManufacturerComboBox.Margin = new Padding(4);
+            Flow5ManufacturerComboBox.Name = "Flow5ManufacturerComboBox";
+            Flow5ManufacturerComboBox.Size = new Size(155, 23);
+            Flow5ManufacturerComboBox.TabIndex = 22;
+            Flow5ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow5ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow5ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow5ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow5ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow5ManufactureDateDateTimePicker
+            //
+            Flow5ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow5ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow5ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow5ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow5ManufactureDateDateTimePicker.Name = "Flow5ManufactureDateDateTimePicker";
+            Flow5ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow5ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow5ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow5ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow5ManufactureDateLabel
+            //
+            Flow5ManufactureDateLabel.AutoSize = true;
+            Flow5ManufactureDateLabel.Location = new Point(18, 100);
+            Flow5ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5ManufactureDateLabel.Name = "Flow5ManufactureDateLabel";
+            Flow5ManufactureDateLabel.Size = new Size(111, 15);
+            Flow5ManufactureDateLabel.TabIndex = 24;
+            Flow5ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // Flow5ManufacturerLabel
+            //
+            Flow5ManufacturerLabel.AutoSize = true;
+            Flow5ManufacturerLabel.Location = new Point(18, 70);
+            Flow5ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5ManufacturerLabel.Name = "Flow5ManufacturerLabel";
+            Flow5ManufacturerLabel.Size = new Size(92, 15);
+            Flow5ManufacturerLabel.TabIndex = 23;
+            Flow5ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow5TypeComboBox
+            //
+            Flow5TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow5TypeComboBox.Location = new Point(168, 38);
+            Flow5TypeComboBox.Margin = new Padding(4);
+            Flow5TypeComboBox.Name = "Flow5TypeComboBox";
+            Flow5TypeComboBox.Size = new Size(155, 23);
+            Flow5TypeComboBox.TabIndex = 20;
+            Flow5TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow5TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow5TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow5TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow5TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow5TypeLabel
+            //
+            Flow5TypeLabel.AutoSize = true;
+            Flow5TypeLabel.Location = new Point(18, 40);
+            Flow5TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5TypeLabel.Name = "Flow5TypeLabel";
+            Flow5TypeLabel.Size = new Size(28, 15);
+            Flow5TypeLabel.TabIndex = 21;
+            Flow5TypeLabel.Text = "Тип";
+            // 
+            // Flow5ModificationComboBox
+            //
+            Flow5ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow5ModificationComboBox.FormattingEnabled = true;
+            Flow5ModificationComboBox.Location = new Point(168, 126);
+            Flow5ModificationComboBox.Margin = new Padding(4);
+            Flow5ModificationComboBox.Name = "Flow5ModificationComboBox";
+            Flow5ModificationComboBox.Size = new Size(155, 23);
+            Flow5ModificationComboBox.TabIndex = 24;
+            Flow5ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow5ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow5ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow5ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow5ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            //
+            // Flow5ModificationLabel
+            // 
+            Flow5ModificationLabel.AutoSize = true;
+            Flow5ModificationLabel.Location = new Point(18, 130);
+            Flow5ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5ModificationLabel.Name = "Flow5ModificationLabel";
+            Flow5ModificationLabel.Size = new Size(86, 15);
+            Flow5ModificationLabel.TabIndex = 25;
+            Flow5ModificationLabel.Text = "Модификация";
+            // 
+            // Flow5FactoryNumberTextBox
+            //
+            Flow5FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow5FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow5FactoryNumberTextBox.Name = "Flow5FactoryNumberTextBox";
+            Flow5FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow5FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow5RegistrationNumberTextBox
+            //
+            Flow5RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow5RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow5RegistrationNumberTextBox.Name = "Flow5RegistrationNumberTextBox";
+            Flow5RegistrationNumberTextBox.ReadOnly = true;
+            Flow5RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow5RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow5RegistrationNumberLabel
+            //
+            Flow5RegistrationNumberLabel.AutoSize = true;
+            Flow5RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow5RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5RegistrationNumberLabel.Name = "Flow5RegistrationNumberLabel";
+            Flow5RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow5RegistrationNumberLabel.TabIndex = 26;
+            Flow5RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow5FactoryNumberLabel
+            //
+            Flow5FactoryNumberLabel.AutoSize = true;
+            Flow5FactoryNumberLabel.Location = new Point(18, 190);
+            Flow5FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow5FactoryNumberLabel.Name = "Flow5FactoryNumberLabel";
+            Flow5FactoryNumberLabel.Size = new Size(104, 15);
+            Flow5FactoryNumberLabel.TabIndex = 29;
+            Flow5FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // Flow6GroupBox
+            // 
+            Flow6GroupBox.Controls.Add(Flow6TitleLabel);
+            Flow6GroupBox.Controls.Add(Flow6CheckBox);
+            Flow6GroupBox.Controls.Add(Flow6ManufacturerComboBox);
+            Flow6GroupBox.Controls.Add(Flow6ManufactureDateDateTimePicker);
+            Flow6GroupBox.Controls.Add(Flow6ManufactureDateLabel);
+            Flow6GroupBox.Controls.Add(Flow6ManufacturerLabel);
+            Flow6GroupBox.Controls.Add(Flow6TypeComboBox);
+            Flow6GroupBox.Controls.Add(Flow6TypeLabel);
+            Flow6GroupBox.Controls.Add(Flow6ModificationComboBox);
+            Flow6GroupBox.Controls.Add(Flow6ModificationLabel);
+            Flow6GroupBox.Controls.Add(Flow6RegistrationNumberTextBox);
+            Flow6GroupBox.Controls.Add(Flow6RegistrationNumberLabel);
+            Flow6GroupBox.Controls.Add(Flow6FactoryNumberTextBox);
+            Flow6GroupBox.Controls.Add(Flow6FactoryNumberLabel);
+            Flow6GroupBox.Location = new Point(757, 346);
+            Flow6GroupBox.Margin = new Padding(4);
+            Flow6GroupBox.Name = "Flow6GroupBox";
+            Flow6GroupBox.Padding = new Padding(4);
+            Flow6GroupBox.Size = new Size(342, 281);
+            Flow6GroupBox.TabIndex = 37;
+            Flow6GroupBox.TabStop = false;
+            Flow6GroupBox.Tag = "FirstFlowmeter";
+            // 
+            // Flow6TitleLabel
+            // 
+            Flow6TitleLabel.AutoSize = true;
+            Flow6TitleLabel.Font = new Font("Microsoft Sans Serif", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 204);
+            Flow6TitleLabel.Location = new Point(18, 0);
+            Flow6TitleLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6TitleLabel.Name = "Flow6TitleLabel";
+            Flow6TitleLabel.Size = new Size(156, 24);
+            Flow6TitleLabel.TabIndex = 35;
+            Flow6TitleLabel.Text = "Расходомер №6";
+            // 
+            // Flow6CheckBox
+            // 
+            Flow6CheckBox.AutoSize = true;
+            Flow6CheckBox.Font = new Font("Microsoft Sans Serif", 8.25F, FontStyle.Bold, GraphicsUnit.Point, 204);
+            Flow6CheckBox.Location = new Point(228, 0);
+            Flow6CheckBox.Margin = new Padding(4);
+            Flow6CheckBox.Name = "Flow6CheckBox";
+            Flow6CheckBox.Size = new Size(97, 17);
+            Flow6CheckBox.TabIndex = 49;
+            Flow6CheckBox.Text = "Установлен";
+            Flow6CheckBox.UseVisualStyleBackColor = true;
+            Flow6CheckBox.CheckedChanged += FlowCheckBoxCheckedChanged;
+            // 
+            // Flow6ManufacturerComboBox
+            //
+            Flow6ManufacturerComboBox.AllowDrop = true;
+            Flow6ManufacturerComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6ManufacturerComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow6ManufacturerComboBox.FormattingEnabled = true;
+            Flow6ManufacturerComboBox.IntegralHeight = false;
+            Flow6ManufacturerComboBox.Location = new Point(168, 67);
+            Flow6ManufacturerComboBox.Margin = new Padding(4);
+            Flow6ManufacturerComboBox.Name = "Flow6ManufacturerComboBox";
+            Flow6ManufacturerComboBox.Size = new Size(155, 23);
+            Flow6ManufacturerComboBox.TabIndex = 22;
+            Flow6ManufacturerComboBox.SelectedIndexChanged += ManufacturerComboBoxSelectedIndexChanged;
+            Flow6ManufacturerComboBox.Click += ManufacturerComboBoxClick;
+            Flow6ManufacturerComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow6ManufacturerComboBox.KeyUp += ManufacturerComboBoxKeyUp;
+            Flow6ManufacturerComboBox.DropDownClosed += RestoreComboText;
+            //
+            // Flow6ManufactureDateDateTimePicker
+            //
+            Flow6ManufactureDateDateTimePicker.Location = new Point(168, 96);
+            Flow6ManufactureDateDateTimePicker.Margin = new Padding(3, 2, 3, 2);
+            Flow6ManufactureDateDateTimePicker.CustomFormat = "dd.MM.yyyy";
+            Flow6ManufactureDateDateTimePicker.Format = DateTimePickerFormat.Custom;
+            Flow6ManufactureDateDateTimePicker.Name = "Flow6ManufactureDateDateTimePicker";
+            Flow6ManufactureDateDateTimePicker.Size = new Size(155, 23);
+            Flow6ManufactureDateDateTimePicker.TabIndex = 24;
+            Flow6ManufactureDateDateTimePicker.Value = new DateTime(2025, 8, 31, 0, 0, 0, 0);
+            Flow6ManufactureDateDateTimePicker.ValueChanged += ManufactureDateDateTimePickerValueChanged;
+            //
+            // Flow6ManufactureDateLabel
+            //
+            Flow6ManufactureDateLabel.AutoSize = true;
+            Flow6ManufactureDateLabel.Location = new Point(18, 100);
+            Flow6ManufactureDateLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6ManufactureDateLabel.Name = "Flow6ManufactureDateLabel";
+            Flow6ManufactureDateLabel.Size = new Size(111, 15);
+            Flow6ManufactureDateLabel.TabIndex = 24;
+            Flow6ManufactureDateLabel.Text = "Дата изготовления";
+            //
+            // Flow6ManufacturerLabel
+            //
+            Flow6ManufacturerLabel.AutoSize = true;
+            Flow6ManufacturerLabel.Location = new Point(18, 70);
+            Flow6ManufacturerLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6ManufacturerLabel.Name = "Flow6ManufacturerLabel";
+            Flow6ManufacturerLabel.Size = new Size(92, 15);
+            Flow6ManufacturerLabel.TabIndex = 23;
+            Flow6ManufacturerLabel.Text = "Производитель";
+            // 
+            // Flow6TypeComboBox
+            //
+            Flow6TypeComboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Flow6TypeComboBox.Location = new Point(168, 38);
+            Flow6TypeComboBox.Margin = new Padding(4);
+            Flow6TypeComboBox.Name = "Flow6TypeComboBox";
+            Flow6TypeComboBox.Size = new Size(155, 23);
+            Flow6TypeComboBox.TabIndex = 20;
+            Flow6TypeComboBox.SelectedIndexChanged += TypeComboBoxSelectedIndexChanged;
+            Flow6TypeComboBox.KeyDown += MeterTypeComboBoxKeyDown;
+            Flow6TypeComboBox.KeyUp += MeterTypeComboBoxKeyUp;
+            Flow6TypeComboBox.Click += MeterTypeComboBoxClick;
+            Flow6TypeComboBox.DropDownClosed += RestoreComboText;
+            // 
+            // Flow6TypeLabel
+            //
+            Flow6TypeLabel.AutoSize = true;
+            Flow6TypeLabel.Location = new Point(18, 40);
+            Flow6TypeLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6TypeLabel.Name = "Flow6TypeLabel";
+            Flow6TypeLabel.Size = new Size(28, 15);
+            Flow6TypeLabel.TabIndex = 21;
+            Flow6TypeLabel.Text = "Тип";
+            // 
+            // Flow6ModificationComboBox
+            //
+            Flow6ModificationComboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            Flow6ModificationComboBox.FormattingEnabled = true;
+            Flow6ModificationComboBox.Location = new Point(168, 126);
+            Flow6ModificationComboBox.Margin = new Padding(4);
+            Flow6ModificationComboBox.Name = "Flow6ModificationComboBox";
+            Flow6ModificationComboBox.Size = new Size(155, 23);
+            Flow6ModificationComboBox.TabIndex = 24;
+            Flow6ModificationComboBox.TextUpdate += ModificationComboBoxTextUpdate;
+            Flow6ModificationComboBox.KeyDown += ModificationComboBoxKeyDown;
+            Flow6ModificationComboBox.Click += ModificationComboBoxClick;
+            Flow6ModificationComboBox.DropDownClosed += RestoreComboText;
+            Flow6ModificationComboBox.SelectedIndexChanged += ModificationComboBoxSelectedIndexChanged;
+            // 
+            // Flow6ModificationLabel
+            // 
+            Flow6ModificationLabel.AutoSize = true;
+            Flow6ModificationLabel.Location = new Point(18, 130);
+            Flow6ModificationLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6ModificationLabel.Name = "Flow6ModificationLabel";
+            Flow6ModificationLabel.Size = new Size(86, 15);
+            Flow6ModificationLabel.TabIndex = 25;
+            Flow6ModificationLabel.Text = "Модификация";
+            // 
+            // Flow6FactoryNumberTextBox
+            //
+            Flow6FactoryNumberTextBox.Location = new Point(168, 185);
+            Flow6FactoryNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow6FactoryNumberTextBox.Name = "Flow6FactoryNumberTextBox";
+            Flow6FactoryNumberTextBox.Size = new Size(155, 23);
+            Flow6FactoryNumberTextBox.TabIndex = 28;
+            //
+            // Flow6RegistrationNumberTextBox
+            //
+            Flow6RegistrationNumberTextBox.Location = new Point(168, 155);
+            Flow6RegistrationNumberTextBox.Margin = new Padding(3, 2, 3, 2);
+            Flow6RegistrationNumberTextBox.Name = "Flow6RegistrationNumberTextBox";
+            Flow6RegistrationNumberTextBox.ReadOnly = true;
+            Flow6RegistrationNumberTextBox.Size = new Size(155, 23);
+            Flow6RegistrationNumberTextBox.TabIndex = 27;
+            //
+            // Flow6RegistrationNumberLabel
+            //
+            Flow6RegistrationNumberLabel.AutoSize = true;
+            Flow6RegistrationNumberLabel.Location = new Point(18, 160);
+            Flow6RegistrationNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6RegistrationNumberLabel.Name = "Flow6RegistrationNumberLabel";
+            Flow6RegistrationNumberLabel.Size = new Size(134, 15);
+            Flow6RegistrationNumberLabel.TabIndex = 26;
+            Flow6RegistrationNumberLabel.Text = "Номер госреестра СИ";
+            //
+            // Flow6FactoryNumberLabel
+            //
+            Flow6FactoryNumberLabel.AutoSize = true;
+            Flow6FactoryNumberLabel.Location = new Point(18, 190);
+            Flow6FactoryNumberLabel.Margin = new Padding(4, 0, 4, 0);
+            Flow6FactoryNumberLabel.Name = "Flow6FactoryNumberLabel";
+            Flow6FactoryNumberLabel.Size = new Size(104, 15);
+            Flow6FactoryNumberLabel.TabIndex = 29;
+            Flow6FactoryNumberLabel.Text = "Заводской номер";
+            // 
+            // NextButton
+            // 
+            NextButton.Location = new Point(1012, 682);
+            NextButton.Margin = new Padding(4);
+            NextButton.Name = "NextButton";
+            NextButton.Size = new Size(88, 26);
+            NextButton.TabIndex = 42;
+            NextButton.Text = "Далее";
+            NextButton.UseVisualStyleBackColor = true;
+            //
+            // ExitButton
+            //
+            ExitButton.Location = new Point(60, 682);
+            ExitButton.Margin = new Padding(4);
+            ExitButton.Name = "ExitButton";
+            ExitButton.Size = new Size(88, 26);
+            ExitButton.TabIndex = 43;
+            ExitButton.Text = "Выход";
+            ExitButton.UseVisualStyleBackColor = true;
             //
             // MetersSetupForm
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1158, 728);
-            Controls.Add(button1);
-            Controls.Add(Next_B);
-            Controls.Add(Flow6_GB);
-            Controls.Add(Flow5_GB);
-            Controls.Add(Flow4_GB);
-            Controls.Add(Flow3_GB);
-            Controls.Add(Flow2_GB);
-            Controls.Add(Flow1_GB);
-            Controls.Add(label1);
+            Controls.Add(ExitButton);
+            Controls.Add(NextButton);
+            Controls.Add(Flow6GroupBox);
+            Controls.Add(Flow5GroupBox);
+            Controls.Add(Flow4GroupBox);
+            Controls.Add(Flow3GroupBox);
+            Controls.Add(Flow2GroupBox);
+            Controls.Add(Flow1GroupBox);
+            Controls.Add(HeaderLabel);
             Margin = new Padding(4);
             Name = "MetersSetupForm";
             StartPosition = FormStartPosition.CenterScreen;
             Text = "Настройка параметров поверяемых преобразователей";
-            Load += MetersSetupForm_Load;
-            Flow1_GB.ResumeLayout(false);
-            Flow1_GB.PerformLayout();
-            Flow2_GB.ResumeLayout(false);
-            Flow2_GB.PerformLayout();
-            Flow3_GB.ResumeLayout(false);
-            Flow3_GB.PerformLayout();
-            Flow4_GB.ResumeLayout(false);
-            Flow4_GB.PerformLayout();
-            Flow5_GB.ResumeLayout(false);
-            Flow5_GB.PerformLayout();
-            Flow6_GB.ResumeLayout(false);
-            Flow6_GB.PerformLayout();
+            Load += MetersSetupFormLoad;
+            Flow1GroupBox.ResumeLayout(false);
+            Flow1GroupBox.PerformLayout();
+            Flow2GroupBox.ResumeLayout(false);
+            Flow2GroupBox.PerformLayout();
+            Flow3GroupBox.ResumeLayout(false);
+            Flow3GroupBox.PerformLayout();
+            Flow4GroupBox.ResumeLayout(false);
+            Flow4GroupBox.PerformLayout();
+            Flow5GroupBox.ResumeLayout(false);
+            Flow5GroupBox.PerformLayout();
+            Flow6GroupBox.ResumeLayout(false);
+            Flow6GroupBox.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
         }
 
         #endregion
 
-        private System.ComponentModel.BackgroundWorker backgroundWorker1;
-        private System.Windows.Forms.TextBox Flow1_ZavodskNomer_TB;
-        private System.Windows.Forms.Label Flow1_ZavodskNomer_Label;
-        private System.Windows.Forms.Label Flow1_Modification_Label;
-        private System.Windows.Forms.ComboBox Flow1_Modification_CB;
-        private System.Windows.Forms.Label Flow1_Type_Label;
-        private System.Windows.Forms.ComboBox Flow1_Type_CB;
-        private System.Windows.Forms.Label Flow1_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow1_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow1_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow1_ManufactureDate_Label;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.GroupBox Flow1_GB;
-        private System.Windows.Forms.Label Flow1_Title_Label;
-        private System.Windows.Forms.TextBox Flow1_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow1_RegistrationNumber_Label;
-        private System.Windows.Forms.GroupBox Flow2_GB;
-        private System.Windows.Forms.Label Flow2_Title_Label;
-        private System.Windows.Forms.ComboBox Flow2_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow2_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow2_ManufactureDate_Label;
-        private System.Windows.Forms.Label Flow2_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow2_Type_CB;
-        private System.Windows.Forms.Label Flow2_Type_Label;
-        private System.Windows.Forms.ComboBox Flow2_Modification_CB;
-        private System.Windows.Forms.Label Flow2_Modification_Label;
-        private System.Windows.Forms.TextBox Flow2_ZavodskNomer_TB;
-        private System.Windows.Forms.TextBox Flow2_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow2_RegistrationNumber_Label;
-        private System.Windows.Forms.Label Flow2_ZavodskNomer_Label;
-        private System.Windows.Forms.GroupBox Flow3_GB;
-        private System.Windows.Forms.Label Flow3_Title_Label;
-        private System.Windows.Forms.ComboBox Flow3_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow3_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow3_ManufactureDate_Label;
-        private System.Windows.Forms.Label Flow3_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow3_Type_CB;
-        private System.Windows.Forms.Label Flow3_Type_Label;
-        private System.Windows.Forms.ComboBox Flow3_Modification_CB;
-        private System.Windows.Forms.Label Flow3_Modification_Label;
-        private System.Windows.Forms.TextBox Flow3_ZavodskNomer_TB;
-        private System.Windows.Forms.TextBox Flow3_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow3_RegistrationNumber_Label;
-        private System.Windows.Forms.Label Flow3_ZavodskNomer_Label;
-        private System.Windows.Forms.GroupBox Flow4_GB;
-        private System.Windows.Forms.Label Flow4_Title_Label;
-        private System.Windows.Forms.ComboBox Flow4_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow4_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow4_ManufactureDate_Label;
-        private System.Windows.Forms.Label Flow4_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow4_Type_CB;
-        private System.Windows.Forms.Label Flow4_Type_Label;
-        private System.Windows.Forms.ComboBox Flow4_Modification_CB;
-        private System.Windows.Forms.Label Flow4_Modification_Label;
-        private System.Windows.Forms.TextBox Flow4_ZavodskNomer_TB;
-        private System.Windows.Forms.TextBox Flow4_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow4_RegistrationNumber_Label;
-        private System.Windows.Forms.Label Flow4_ZavodskNomer_Label;
-        private System.Windows.Forms.GroupBox Flow5_GB;
-        private System.Windows.Forms.Label Flow5_Title_Label;
-        private System.Windows.Forms.ComboBox Flow5_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow5_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow5_ManufactureDate_Label;
-        private System.Windows.Forms.Label Flow5_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow5_Type_CB;
-        private System.Windows.Forms.Label Flow5_Type_Label;
-        private System.Windows.Forms.ComboBox Flow5_Modification_CB;
-        private System.Windows.Forms.Label Flow5_Modification_Label;
-        private System.Windows.Forms.TextBox Flow5_ZavodskNomer_TB;
-        private System.Windows.Forms.TextBox Flow5_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow5_RegistrationNumber_Label;
-        private System.Windows.Forms.Label Flow5_ZavodskNomer_Label;
-        private System.Windows.Forms.GroupBox Flow6_GB;
-        private System.Windows.Forms.Label Flow6_Title_Label;
-        private System.Windows.Forms.ComboBox Flow6_Manufacturer_CB;
-        private System.Windows.Forms.DateTimePicker Flow6_ManufactureDate_DTP;
-        private System.Windows.Forms.Label Flow6_ManufactureDate_Label;
-        private System.Windows.Forms.Label Flow6_Manufacturer_Label;
-        private System.Windows.Forms.ComboBox Flow6_Type_CB;
-        private System.Windows.Forms.Label Flow6_Type_Label;
-        private System.Windows.Forms.ComboBox Flow6_Modification_CB;
-        private System.Windows.Forms.Label Flow6_Modification_Label;
-        private System.Windows.Forms.TextBox Flow6_ZavodskNomer_TB;
-        private System.Windows.Forms.TextBox Flow6_RegistrationNumber_TB;
-        private System.Windows.Forms.Label Flow6_RegistrationNumber_Label;
-        private System.Windows.Forms.Label Flow6_ZavodskNomer_Label;
-        private System.Windows.Forms.Button Next_B;
-        private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.CheckBox Flow1_CB;
-        private System.Windows.Forms.CheckBox Flow2_CB;
-        private System.Windows.Forms.CheckBox Flow3_CB;
-        private System.Windows.Forms.CheckBox Flow6_CB;
-        private System.Windows.Forms.CheckBox Flow5_CB;
-        private System.Windows.Forms.CheckBox Flow4_CB;
+        private System.ComponentModel.BackgroundWorker BackgroundWorker;
+        private System.Windows.Forms.TextBox Flow1FactoryNumberTextBox;
+        private System.Windows.Forms.Label Flow1FactoryNumberLabel;
+        private System.Windows.Forms.Label Flow1ModificationLabel;
+        private System.Windows.Forms.ComboBox Flow1ModificationComboBox;
+        private System.Windows.Forms.Label Flow1TypeLabel;
+        private System.Windows.Forms.ComboBox Flow1TypeComboBox;
+        private System.Windows.Forms.Label Flow1ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow1ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow1ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow1ManufactureDateLabel;
+        private System.Windows.Forms.Label HeaderLabel;
+        private System.Windows.Forms.GroupBox Flow1GroupBox;
+        private System.Windows.Forms.Label Flow1TitleLabel;
+        private System.Windows.Forms.TextBox Flow1RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow1RegistrationNumberLabel;
+        private System.Windows.Forms.GroupBox Flow2GroupBox;
+        private System.Windows.Forms.Label Flow2TitleLabel;
+        private System.Windows.Forms.ComboBox Flow2ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow2ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow2ManufactureDateLabel;
+        private System.Windows.Forms.Label Flow2ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow2TypeComboBox;
+        private System.Windows.Forms.Label Flow2TypeLabel;
+        private System.Windows.Forms.ComboBox Flow2ModificationComboBox;
+        private System.Windows.Forms.Label Flow2ModificationLabel;
+        private System.Windows.Forms.TextBox Flow2FactoryNumberTextBox;
+        private System.Windows.Forms.TextBox Flow2RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow2RegistrationNumberLabel;
+        private System.Windows.Forms.Label Flow2FactoryNumberLabel;
+        private System.Windows.Forms.GroupBox Flow3GroupBox;
+        private System.Windows.Forms.Label Flow3TitleLabel;
+        private System.Windows.Forms.ComboBox Flow3ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow3ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow3ManufactureDateLabel;
+        private System.Windows.Forms.Label Flow3ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow3TypeComboBox;
+        private System.Windows.Forms.Label Flow3TypeLabel;
+        private System.Windows.Forms.ComboBox Flow3ModificationComboBox;
+        private System.Windows.Forms.Label Flow3ModificationLabel;
+        private System.Windows.Forms.TextBox Flow3FactoryNumberTextBox;
+        private System.Windows.Forms.TextBox Flow3RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow3RegistrationNumberLabel;
+        private System.Windows.Forms.Label Flow3FactoryNumberLabel;
+        private System.Windows.Forms.GroupBox Flow4GroupBox;
+        private System.Windows.Forms.Label Flow4TitleLabel;
+        private System.Windows.Forms.ComboBox Flow4ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow4ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow4ManufactureDateLabel;
+        private System.Windows.Forms.Label Flow4ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow4TypeComboBox;
+        private System.Windows.Forms.Label Flow4TypeLabel;
+        private System.Windows.Forms.ComboBox Flow4ModificationComboBox;
+        private System.Windows.Forms.Label Flow4ModificationLabel;
+        private System.Windows.Forms.TextBox Flow4FactoryNumberTextBox;
+        private System.Windows.Forms.TextBox Flow4RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow4RegistrationNumberLabel;
+        private System.Windows.Forms.Label Flow4FactoryNumberLabel;
+        private System.Windows.Forms.GroupBox Flow5GroupBox;
+        private System.Windows.Forms.Label Flow5TitleLabel;
+        private System.Windows.Forms.ComboBox Flow5ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow5ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow5ManufactureDateLabel;
+        private System.Windows.Forms.Label Flow5ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow5TypeComboBox;
+        private System.Windows.Forms.Label Flow5TypeLabel;
+        private System.Windows.Forms.ComboBox Flow5ModificationComboBox;
+        private System.Windows.Forms.Label Flow5ModificationLabel;
+        private System.Windows.Forms.TextBox Flow5FactoryNumberTextBox;
+        private System.Windows.Forms.TextBox Flow5RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow5RegistrationNumberLabel;
+        private System.Windows.Forms.Label Flow5FactoryNumberLabel;
+        private System.Windows.Forms.GroupBox Flow6GroupBox;
+        private System.Windows.Forms.Label Flow6TitleLabel;
+        private System.Windows.Forms.ComboBox Flow6ManufacturerComboBox;
+        private System.Windows.Forms.DateTimePicker Flow6ManufactureDateDateTimePicker;
+        private System.Windows.Forms.Label Flow6ManufactureDateLabel;
+        private System.Windows.Forms.Label Flow6ManufacturerLabel;
+        private System.Windows.Forms.ComboBox Flow6TypeComboBox;
+        private System.Windows.Forms.Label Flow6TypeLabel;
+        private System.Windows.Forms.ComboBox Flow6ModificationComboBox;
+        private System.Windows.Forms.Label Flow6ModificationLabel;
+        private System.Windows.Forms.TextBox Flow6FactoryNumberTextBox;
+        private System.Windows.Forms.TextBox Flow6RegistrationNumberTextBox;
+        private System.Windows.Forms.Label Flow6RegistrationNumberLabel;
+        private System.Windows.Forms.Label Flow6FactoryNumberLabel;
+        private System.Windows.Forms.Button NextButton;
+        private System.Windows.Forms.Button ExitButton;
+        private System.Windows.Forms.CheckBox Flow1CheckBox;
+        private System.Windows.Forms.CheckBox Flow2CheckBox;
+        private System.Windows.Forms.CheckBox Flow3CheckBox;
+        private System.Windows.Forms.CheckBox Flow6CheckBox;
+        private System.Windows.Forms.CheckBox Flow5CheckBox;
+        private System.Windows.Forms.CheckBox Flow4CheckBox;
     }
 }

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -77,7 +77,10 @@ namespace PoverkaWinForms.Forms.Verifier
             if (_updating || sender is not ComboBox combo)
                 return;
 
-            if (string.IsNullOrEmpty(combo.Text) && _previousTexts.TryGetValue(combo, out var text))
+            bool noSelection = combo.SelectedIndex < 0;
+            bool noText = string.IsNullOrEmpty(combo.Text);
+
+            if (noSelection && noText && _previousTexts.TryGetValue(combo, out var text))
             {
                 _updating = true;
                 combo.Text = text;

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -31,12 +31,12 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void InitializeFlowMeters()
         {
-            _flowMeters.Add(new FlowMeterSection(Rashodomer1_CB, Rashodomer1_GB, label8, Flow1_Name_SI_CB, Flow1_GosReestr_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer2_CB, Rashodomer2_GB, label10, Flow2_Name_SI_CB, Flow2_GosReestr_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer3_CB, Rashodomer3_GB, label9, Flow3_Name_SI_CB, Flow3_GosReestr_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer4_CB, Rashodomer4_GB, label25, Flow4_Name_SI_CB, Flow4_GosReestr_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer5_CB, Rashodomer5_GB, label33, Flow5_Name_SI_CB, Flow5_GosReestr_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer6_CB, Rashodomer6_GB, label41, Flow6_Name_SI_CB, Flow6_GosReestr_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer1_CB, Rashodomer1_GB, label8, Flow1_Type_CB, Flow1_Manufacturer_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer2_CB, Rashodomer2_GB, label10, Flow2_Type_CB, Flow2_Manufacturer_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer3_CB, Rashodomer3_GB, label9, Flow3_Type_CB, Flow3_Manufacturer_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer4_CB, Rashodomer4_GB, label25, Flow4_Type_CB, Flow4_Manufacturer_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer5_CB, Rashodomer5_GB, label33, Flow5_Type_CB, Flow5_Manufacturer_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer6_CB, Rashodomer6_GB, label41, Flow6_Type_CB, Flow6_Manufacturer_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
@@ -96,22 +96,22 @@ namespace PoverkaWinForms.Forms.Verifier
             _previousTexts.Remove(combo);
         }
 
-        private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow1_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
 
-        private void Flow2_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow2_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
 
-        private void Flow3_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow3_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
 
-        private void Flow4_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow4_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
 
-        private void Flow5_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow5_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
 
-        private void Flow6_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow6_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
 
         internal async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
@@ -397,22 +397,22 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void GosReestrCB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow1_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
 
-        private void Flow2_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow2_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
 
-        private void Flow3_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow3_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
 
-        private void Flow4_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow4_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
 
-        private void Flow5_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow5_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
 
-        private void Flow6_GosReestr_CB_SelectedIndexChanged(object sender, EventArgs e) =>
+        private void Flow6_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
 
         private void Flow1_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -36,12 +36,12 @@ namespace PoverkaWinForms.Forms.Verifier
             if (DesignMode)
                 return;
 
-            Rashodomer1_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer2_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer3_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer4_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer5_CB_CheckedChanged(null, EventArgs.Empty);
-            Rashodomer6_CB_CheckedChanged(null, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer1_CB, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer2_CB, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer3_CB, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer4_CB, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer5_CB, EventArgs.Empty);
+            RashodomerCB_CheckedChanged(Rashodomer6_CB, EventArgs.Empty);
 
             await _meterTypeService.GetAllAsync(string.Empty, 10);
             await _manufacturerService.GetAllAsync(string.Empty, 10);
@@ -518,64 +518,38 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Flow6_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             UpdateRegistrationNumber(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
 
-        private async void Rashodomer1_CB_CheckedChanged(object? sender, EventArgs e)
+        private async void RashodomerCB_CheckedChanged(object? sender, EventArgs e)
         {
-            ToggleGroupControls(Rashodomer1_GB, Rashodomer1_CB, label8);
-            if (Rashodomer1_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow1_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow1_GosReestr_CB, string.Empty, 10);
-            }
-        }
+            if (sender is not CheckBox checkBox)
+                return;
 
-        private async void Rashodomer2_CB_CheckedChanged(object? sender, EventArgs e)
-        {
-            ToggleGroupControls(Rashodomer2_GB, Rashodomer2_CB, label10);
-            if (Rashodomer2_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow2_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow2_GosReestr_CB, string.Empty, 10);
-            }
-        }
+            string flow = new string(checkBox.Name.Where(char.IsDigit).ToArray());
+            if (string.IsNullOrEmpty(flow))
+                return;
 
-        private async void Rashodomer3_CB_CheckedChanged(object? sender, EventArgs e)
-        {
-            ToggleGroupControls(Rashodomer3_GB, Rashodomer3_CB, label9);
-            if (Rashodomer3_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow3_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow3_GosReestr_CB, string.Empty, 10);
-            }
-        }
+            GroupBox? groupBox = Controls.Find($"Rashodomer{flow}_GB", true)
+                .FirstOrDefault() as GroupBox;
+            if (groupBox is null)
+                return;
 
-        private async void Rashodomer6_CB_CheckedChanged(object? sender, EventArgs e)
-        {
-            ToggleGroupControls(Rashodomer6_GB, Rashodomer6_CB, label41);
-            if (Rashodomer6_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow6_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow6_GosReestr_CB, string.Empty, 10);
-            }
-        }
+            Label? caption = groupBox.Controls.OfType<Label>().FirstOrDefault();
+            if (caption is null)
+                return;
 
-        private async void Rashodomer5_CB_CheckedChanged(object? sender, EventArgs e)
-        {
-            ToggleGroupControls(Rashodomer5_GB, Rashodomer5_CB, label33);
-            if (Rashodomer5_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow5_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow5_GosReestr_CB, string.Empty, 10);
-            }
-        }
+            ToggleGroupControls(groupBox, checkBox, caption);
 
-        private async void Rashodomer4_CB_CheckedChanged(object? sender, EventArgs e)
-        {
-            ToggleGroupControls(Rashodomer4_GB, Rashodomer4_CB, label25);
-            if (Rashodomer4_CB.Checked)
-            {
-                await PopulateMeterTypesAsync(Flow4_Name_SI_CB, string.Empty, 10);
-                await PopulateManufacturersAsync(Flow4_GosReestr_CB, string.Empty, 10);
-            }
+            if (!checkBox.Checked)
+                return;
+
+            ComboBox? meterType = Controls.Find($"Flow{flow}_Name_SI_CB", true)
+                .FirstOrDefault() as ComboBox;
+            if (meterType is not null)
+                await PopulateMeterTypesAsync(meterType, string.Empty, 10);
+
+            ComboBox? manufacturer = Controls.Find($"Flow{flow}_GosReestr_CB", true)
+                .FirstOrDefault() as ComboBox;
+            if (manufacturer is not null)
+                await PopulateManufacturersAsync(manufacturer, string.Empty, 10);
         }
 
         private static void ToggleGroupControls(GroupBox groupBox, CheckBox checkBox, Label caption)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -20,65 +20,7 @@ namespace PoverkaWinForms.Forms.Verifier
         private readonly Dictionary<ComboBox, string> _previousTexts = new();
         private readonly List<FlowMeterSection> _flowMeters = new();
 
-        private sealed class FlowMeterSection
-        {
-            public FlowMeterSection(
-                CheckBox checkBox,
-                GroupBox groupBox,
-                Label caption,
-                ComboBox meterType,
-                ComboBox manufacturer,
-                ComboBox modification,
-                DateTimePicker manufactureDate,
-                TextBox registrationNumber
-            )
-            {
-                CheckBox = checkBox;
-                GroupBox = groupBox;
-                Caption = caption;
-                MeterType = meterType;
-                Manufacturer = manufacturer;
-                Modification = modification;
-                ManufactureDate = manufactureDate;
-                RegistrationNumber = registrationNumber;
-            }
-
-            public CheckBox CheckBox { get; }
-            public GroupBox GroupBox { get; }
-            public Label Caption { get; }
-            public ComboBox MeterType { get; }
-            public ComboBox Manufacturer { get; }
-            public ComboBox Modification { get; }
-            public DateTimePicker ManufactureDate { get; }
-            public TextBox RegistrationNumber { get; }
-
-            public void ToggleControls()
-            {
-                bool visible = CheckBox.Checked;
-                foreach (Control control in GroupBox.Controls)
-                {
-                    if (control != Caption && control != CheckBox)
-                        control.Visible = visible;
-                }
-            }
-
-            public async Task OnCheckedChangedAsync(MetersSetupForm form)
-            {
-                ToggleControls();
-
-                if (!CheckBox.Checked)
-                    return;
-
-                await form.PopulateMeterTypesAsync(MeterType, string.Empty, 10);
-                await form.PopulateManufacturersAsync(Manufacturer, string.Empty, 10);
-            }
-        }
-
-        public MetersSetupForm(
-            MeterTypeService meterTypeService,
-            ManufacturerService manufacturerService,
-            ModificationService modificationService
-        )
+        public MetersSetupForm(MeterTypeService meterTypeService, ManufacturerService manufacturerService, ModificationService modificationService)
         {
             _meterTypeService = meterTypeService;
             _manufacturerService = manufacturerService;
@@ -89,78 +31,12 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void InitializeFlowMeters()
         {
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer1_CB,
-                    Rashodomer1_GB,
-                    label8,
-                    Flow1_Name_SI_CB,
-                    Flow1_GosReestr_CB,
-                    Flow1_Modification_CB,
-                    Flow1_ManufactureDate_DTP,
-                    Flow1_RegistrationNumber_TB
-                )
-            );
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer2_CB,
-                    Rashodomer2_GB,
-                    label10,
-                    Flow2_Name_SI_CB,
-                    Flow2_GosReestr_CB,
-                    Flow2_Modification_CB,
-                    Flow2_ManufactureDate_DTP,
-                    Flow2_RegistrationNumber_TB
-                )
-            );
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer3_CB,
-                    Rashodomer3_GB,
-                    label9,
-                    Flow3_Name_SI_CB,
-                    Flow3_GosReestr_CB,
-                    Flow3_Modification_CB,
-                    Flow3_ManufactureDate_DTP,
-                    Flow3_RegistrationNumber_TB
-                )
-            );
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer4_CB,
-                    Rashodomer4_GB,
-                    label25,
-                    Flow4_Name_SI_CB,
-                    Flow4_GosReestr_CB,
-                    Flow4_Modification_CB,
-                    Flow4_ManufactureDate_DTP,
-                    Flow4_RegistrationNumber_TB
-                )
-            );
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer5_CB,
-                    Rashodomer5_GB,
-                    label33,
-                    Flow5_Name_SI_CB,
-                    Flow5_GosReestr_CB,
-                    Flow5_Modification_CB,
-                    Flow5_ManufactureDate_DTP,
-                    Flow5_RegistrationNumber_TB
-                )
-            );
-            _flowMeters.Add(
-                new FlowMeterSection(
-                    Rashodomer6_CB,
-                    Rashodomer6_GB,
-                    label41,
-                    Flow6_Name_SI_CB,
-                    Flow6_GosReestr_CB,
-                    Flow6_Modification_CB,
-                    Flow6_ManufactureDate_DTP,
-                    Flow6_RegistrationNumber_TB
-                )
-            );
+            _flowMeters.Add(new FlowMeterSection(Rashodomer1_CB, Rashodomer1_GB, label8, Flow1_Name_SI_CB, Flow1_GosReestr_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer2_CB, Rashodomer2_GB, label10, Flow2_Name_SI_CB, Flow2_GosReestr_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer3_CB, Rashodomer3_GB, label9, Flow3_Name_SI_CB, Flow3_GosReestr_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer4_CB, Rashodomer4_GB, label25, Flow4_Name_SI_CB, Flow4_GosReestr_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer5_CB, Rashodomer5_GB, label33, Flow5_Name_SI_CB, Flow5_GosReestr_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Rashodomer6_CB, Rashodomer6_GB, label41, Flow6_Name_SI_CB, Flow6_GosReestr_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
 
             foreach (var meter in _flowMeters)
             {
@@ -248,12 +124,7 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Flow6_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
 
-        private async Task PopulateMeterTypesAsync(
-            ComboBox combo,
-            string search,
-            int? limit = null,
-            bool dropDown = false
-        )
+        internal async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
         {
             var items = await _meterTypeService.GetAllAsync(search, limit);
 
@@ -280,12 +151,7 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        private async Task PopulateManufacturersAsync(
-            ComboBox combo,
-            string search,
-            int? limit = null,
-            bool dropDown = false
-        )
+        internal async Task PopulateManufacturersAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
         {
             var items = await _manufacturerService.GetAllAsync(search, limit);
 
@@ -312,13 +178,7 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        private async Task PopulateModificationsAsync(
-            ComboBox modificationCombo,
-            ComboBox meterTypeCombo,
-            ComboBox manufacturerCombo,
-            DateTimePicker datePicker,
-            TextBox registrationNumberTextBox
-        )
+        private async Task PopulateModificationsAsync(ComboBox modificationCombo, ComboBox meterTypeCombo, ComboBox manufacturerCombo, DateTimePicker datePicker, TextBox registrationNumberTextBox)
         {
             if (meterTypeCombo.SelectedValue is not int meterTypeId)
                 return;
@@ -450,16 +310,14 @@ namespace PoverkaWinForms.Forms.Verifier
                     newIndex = 0;
                 combo.SelectedIndex = newIndex;
 
-                BeginInvoke(
-                    new Action(() =>
-                    {
-                        _updating = true;
-                        combo.Text = text;
-                        combo.SelectionStart = text.Length;
-                        combo.SelectionLength = 0;
-                        _updating = false;
-                    })
-                );
+                BeginInvoke(new Action(() =>
+                {
+                    _updating = true;
+                    combo.Text = text;
+                    combo.SelectionStart = text.Length;
+                    combo.SelectionLength = 0;
+                    _updating = false;
+                }));
             }
         }
 
@@ -502,12 +360,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo)
             {
                 StoreAndClearCombo(combo);
-                await PopulateMeterTypesAsync(
-                    combo,
-                    combo.Text,
-                    combo.Text.Length > 0 ? 20 : 10,
-                    dropDown: true
-                );
+                await PopulateMeterTypesAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
             }
         }
 
@@ -550,12 +403,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo)
             {
                 StoreAndClearCombo(combo);
-                await PopulateManufacturersAsync(
-                    combo,
-                    combo.Text,
-                    combo.Text.Length > 0 ? 20 : 10,
-                    dropDown: true
-                );
+                await PopulateManufacturersAsync(combo, combo.Text, combo.Text.Length > 0 ? 20 : 10, dropDown: true);
             }
         }
 
@@ -606,13 +454,7 @@ namespace PoverkaWinForms.Forms.Verifier
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
             {
                 StoreAndClearCombo(combo);
-                await PopulateModificationsAsync(
-                    combo,
-                    meter.MeterType,
-                    meter.Manufacturer,
-                    meter.ManufactureDate,
-                    meter.RegistrationNumber
-                );
+                await PopulateModificationsAsync(combo, meter.MeterType, meter.Manufacturer, meter.ManufactureDate, meter.RegistrationNumber);
             }
         }
 

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -37,16 +37,6 @@ namespace PoverkaWinForms.Forms.Verifier
             _flowMeters.Add(new FlowMeterSection(Rashodomer4_CB, Rashodomer4_GB, label25, Flow4_Name_SI_CB, Flow4_GosReestr_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
             _flowMeters.Add(new FlowMeterSection(Rashodomer5_CB, Rashodomer5_GB, label33, Flow5_Name_SI_CB, Flow5_GosReestr_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
             _flowMeters.Add(new FlowMeterSection(Rashodomer6_CB, Rashodomer6_GB, label41, Flow6_Name_SI_CB, Flow6_GosReestr_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
-
-            foreach (var meter in _flowMeters)
-            {
-                meter.CheckBox.Tag = meter;
-                meter.MeterType.Tag = meter;
-                meter.Manufacturer.Tag = meter;
-                meter.Modification.Tag = meter;
-                meter.ManufactureDate.Tag = meter;
-                meter.RegistrationNumber.Tag = meter;
-            }
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -31,21 +31,25 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void InitializeFlowMeters()
         {
-            _flowMeters.Add(new FlowMeterSection(Rashodomer1_CB, Rashodomer1_GB, label8, Flow1_Type_CB, Flow1_Manufacturer_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer2_CB, Rashodomer2_GB, label10, Flow2_Type_CB, Flow2_Manufacturer_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer3_CB, Rashodomer3_GB, label9, Flow3_Type_CB, Flow3_Manufacturer_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer4_CB, Rashodomer4_GB, label25, Flow4_Type_CB, Flow4_Manufacturer_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer5_CB, Rashodomer5_GB, label33, Flow5_Type_CB, Flow5_Manufacturer_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Rashodomer6_CB, Rashodomer6_GB, label41, Flow6_Type_CB, Flow6_Manufacturer_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow1_CB, Flow1_GB, Flow1_Title_Label, Flow1_Type_CB, Flow1_Manufacturer_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow2_CB, Flow2_GB, Flow2_Title_Label, Flow2_Type_CB, Flow2_Manufacturer_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow3_CB, Flow3_GB, Flow3_Title_Label, Flow3_Type_CB, Flow3_Manufacturer_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow4_CB, Flow4_GB, Flow4_Title_Label, Flow4_Type_CB, Flow4_Manufacturer_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow5_CB, Flow5_GB, Flow5_Title_Label, Flow5_Type_CB, Flow5_Manufacturer_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow6_CB, Flow6_GB, Flow6_Title_Label, Flow6_Type_CB, Flow6_Manufacturer_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
         {
             if (DesignMode)
+            {
                 return;
+            }
 
             foreach (var meter in _flowMeters)
-                RashodomerCB_CheckedChanged(meter.CheckBox, EventArgs.Empty);
+            {
+                FlowCB_CheckedChanged(meter.CheckBox, EventArgs.Empty);
+            }
 
             await _meterTypeService.GetAllAsync(string.Empty, 10);
             await _manufacturerService.GetAllAsync(string.Empty, 10);
@@ -54,7 +58,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private void ResetModifications(ComboBox modificationCombo, TextBox registrationNumberTextBox)
         {
             if (_updating)
+            {
                 return;
+            }
 
             modificationCombo.DataSource = null;
             modificationCombo.Items.Clear();
@@ -66,7 +72,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private void StoreAndClearCombo(ComboBox combo)
         {
             if (string.IsNullOrEmpty(combo.Text))
+            {
                 return;
+            }
 
             _updating = true;
             _previousTexts[combo] = combo.Text;
@@ -79,7 +87,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private void RestoreComboText(object? sender, EventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
+            {
                 return;
+            }
 
             bool noSelection = combo.SelectedIndex < 0;
             bool noText = string.IsNullOrEmpty(combo.Text);
@@ -99,7 +109,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private void TypeCB_SelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+            {
                 ResetModifications(meter.Modification, meter.RegistrationNumber);
+            }
         }
 
         internal async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
@@ -159,9 +171,14 @@ namespace PoverkaWinForms.Forms.Verifier
         private async Task PopulateModificationsAsync(ComboBox modificationCombo, ComboBox meterTypeCombo, ComboBox manufacturerCombo, DateTimePicker datePicker, TextBox registrationNumberTextBox)
         {
             if (meterTypeCombo.SelectedValue is not int meterTypeId)
+            {
                 return;
+            }
+
             if (manufacturerCombo.SelectedValue is not int manufacturerId)
+            {
                 return;
+            }
 
             var manufactureDate = DateOnly.FromDateTime(datePicker.Value);
             var items = await _modificationService.GetAllAsync(meterTypeId, manufacturerId, manufactureDate);
@@ -181,10 +198,7 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void UpdateRegistrationNumber(ComboBox modificationCombo, TextBox registrationNumberTextBox)
         {
-            if (
-                modificationCombo.SelectedValue is not int modificationId
-                || !_modifications.TryGetValue(modificationCombo, out var items)
-            )
+            if (modificationCombo.SelectedValue is not int modificationId || !_modifications.TryGetValue(modificationCombo, out var items))
             {
                 registrationNumberTextBox.Text = string.Empty;
                 return;
@@ -197,9 +211,14 @@ namespace PoverkaWinForms.Forms.Verifier
         private void ModificationCB_TextUpdate(object? sender, EventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
+            {
                 return;
+            }
+
             if (!_modifications.TryGetValue(combo, out var all))
+            {
                 return;
+            }
 
             var text = combo.Text;
             var filtered = all
@@ -225,7 +244,9 @@ namespace PoverkaWinForms.Forms.Verifier
         private void ModificationCB_KeyDown(object? sender, KeyEventArgs e)
         {
             if (sender is not ComboBox combo)
+            {
                 return;
+            }
 
             if (e.KeyCode == Keys.Enter)
             {
@@ -245,10 +266,14 @@ namespace PoverkaWinForms.Forms.Verifier
         private void MeterTypeCB_KeyDown(object? sender, KeyEventArgs e)
         {
             if (sender is not ComboBox combo)
+            {
                 return;
+            }
 
             if (_searchTokens.TryGetValue(combo, out var prev))
+            {
                 prev.Cancel();
+            }
 
             if (e.KeyCode == Keys.Enter)
             {
@@ -269,7 +294,9 @@ namespace PoverkaWinForms.Forms.Verifier
                 e.Handled = true;
 
                 if (!_typedTexts.TryGetValue(combo, out var text))
+                {
                     text = combo.Text;
+                }
 
                 if (!combo.DroppedDown)
                 {
@@ -280,12 +307,18 @@ namespace PoverkaWinForms.Forms.Verifier
                 int direction = e.KeyCode == Keys.Down ? 1 : -1;
                 int count = combo.Items.Count;
                 if (count == 0)
+                {
                     return;
+                }
                 int newIndex = combo.SelectedIndex + direction;
                 if (newIndex < 0)
+                {
                     newIndex = count - 1;
+                }
                 if (newIndex >= count)
+                {
                     newIndex = 0;
+                }
                 combo.SelectedIndex = newIndex;
 
                 BeginInvoke(new Action(() =>
@@ -302,25 +335,27 @@ namespace PoverkaWinForms.Forms.Verifier
         private async void MeterTypeCB_KeyUp(object? sender, KeyEventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
+            {
                 return;
+            }
 
-            if (
-                e.KeyCode == Keys.Enter
-                || e.KeyCode == Keys.Up
-                || e.KeyCode == Keys.Down
-                || e.KeyCode == Keys.Left
-                || e.KeyCode == Keys.Right
-            )
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down || e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            {
                 return;
+            }
 
             var keyChar = (char)e.KeyValue;
             if (!char.IsLetter(keyChar) && e.KeyCode != Keys.Back && e.KeyCode != Keys.Delete)
+            {
                 return;
+            }
 
             _typedTexts[combo] = combo.Text;
 
             if (_searchTokens.TryGetValue(combo, out var prev))
+            {
                 prev.Cancel();
+            }
 
             var cts = new CancellationTokenSource();
             _searchTokens[combo] = cts;
@@ -345,25 +380,27 @@ namespace PoverkaWinForms.Forms.Verifier
         private async void ManufacturerCB_KeyUp(object? sender, KeyEventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
+            {
                 return;
+            }
 
-            if (
-                e.KeyCode == Keys.Enter
-                || e.KeyCode == Keys.Up
-                || e.KeyCode == Keys.Down
-                || e.KeyCode == Keys.Left
-                || e.KeyCode == Keys.Right
-            )
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Up || e.KeyCode == Keys.Down || e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            {
                 return;
+            }
 
             var keyChar = (char)e.KeyValue;
             if (!char.IsLetter(keyChar) && e.KeyCode != Keys.Back && e.KeyCode != Keys.Delete)
+            {
                 return;
+            }
 
             _typedTexts[combo] = combo.Text;
 
             if (_searchTokens.TryGetValue(combo, out var prev))
+            {
                 prev.Cancel();
+            }
 
             var cts = new CancellationTokenSource();
             _searchTokens[combo] = cts;
@@ -388,13 +425,17 @@ namespace PoverkaWinForms.Forms.Verifier
         private void ManufacturerCB_SelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+            {
                 ResetModifications(meter.Modification, meter.RegistrationNumber);
+            }
         }
 
         private void ManufactureDateDTP_ValueChanged(object? sender, EventArgs e)
         {
             if (sender is DateTimePicker picker && picker.Tag is FlowMeterSection meter)
+            {
                 ResetModifications(meter.Modification, meter.RegistrationNumber);
+            }
         }
 
         private async void ModificationCB_Click(object? sender, EventArgs e)
@@ -409,10 +450,12 @@ namespace PoverkaWinForms.Forms.Verifier
         private void ModificationCB_SelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+            {
                 UpdateRegistrationNumber(combo, meter.RegistrationNumber);
+            }
         }
 
-        private async void RashodomerCB_CheckedChanged(object? sender, EventArgs e)
+        private async void FlowCB_CheckedChanged(object? sender, EventArgs e)
         {
             if (sender is CheckBox checkBox && checkBox.Tag is FlowMeterSection meter)
             {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -433,12 +433,6 @@ namespace PoverkaWinForms.Forms.Verifier
         private void Flow6_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
             ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
 
-        private void label14_Click(object sender, EventArgs e) { }
-
-        private void Next_B_Click(object sender, EventArgs e) { }
-
-        private void button1_Click(object sender, EventArgs e) { }
-
         private async void ModificationCB_Click(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -359,7 +359,7 @@ namespace PoverkaWinForms.Forms.Verifier
             catch (TaskCanceledException) { }
         }
 
-        private async void MeterTypeCB_Click(object? sender, EventArgs e)
+        private async void MeterTypeCB_DropDown(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo)
             {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -96,23 +96,11 @@ namespace PoverkaWinForms.Forms.Verifier
             _previousTexts.Remove(combo);
         }
 
-        private void Flow1_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
-
-        private void Flow2_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
-
-        private void Flow3_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
-
-        private void Flow4_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
-
-        private void Flow5_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
-
-        private void Flow6_Type_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
+        private void TypeCB_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+                ResetModifications(meter.Modification, meter.RegistrationNumber);
+        }
 
         internal async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
         {
@@ -397,41 +385,17 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void Flow1_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
+        private void ManufacturerCB_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+                ResetModifications(meter.Modification, meter.RegistrationNumber);
+        }
 
-        private void Flow2_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
-
-        private void Flow3_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
-
-        private void Flow4_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
-
-        private void Flow5_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
-
-        private void Flow6_Manufacturer_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
-
-        private void Flow1_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
-
-        private void Flow2_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
-
-        private void Flow3_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
-
-        private void Flow4_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
-
-        private void Flow5_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
-
-        private void Flow6_ManufactureDate_DTP_ValueChanged(object sender, EventArgs e) =>
-            ResetModifications(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
+        private void ManufactureDateDTP_ValueChanged(object? sender, EventArgs e)
+        {
+            if (sender is DateTimePicker picker && picker.Tag is FlowMeterSection meter)
+                ResetModifications(meter.Modification, meter.RegistrationNumber);
+        }
 
         private async void ModificationCB_Click(object? sender, EventArgs e)
         {
@@ -442,23 +406,11 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void Flow1_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);
-
-        private void Flow2_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow2_Modification_CB, Flow2_RegistrationNumber_TB);
-
-        private void Flow3_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow3_Modification_CB, Flow3_RegistrationNumber_TB);
-
-        private void Flow4_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow4_Modification_CB, Flow4_RegistrationNumber_TB);
-
-        private void Flow5_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow5_Modification_CB, Flow5_RegistrationNumber_TB);
-
-        private void Flow6_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
-            UpdateRegistrationNumber(Flow6_Modification_CB, Flow6_RegistrationNumber_TB);
+        private void ModificationCB_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
+                UpdateRegistrationNumber(combo, meter.RegistrationNumber);
+        }
 
         private async void RashodomerCB_CheckedChanged(object? sender, EventArgs e)
         {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -31,15 +31,15 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void InitializeFlowMeters()
         {
-            _flowMeters.Add(new FlowMeterSection(Flow1_CB, Flow1_GB, Flow1_Title_Label, Flow1_Type_CB, Flow1_Manufacturer_CB, Flow1_Modification_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Flow2_CB, Flow2_GB, Flow2_Title_Label, Flow2_Type_CB, Flow2_Manufacturer_CB, Flow2_Modification_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Flow3_CB, Flow3_GB, Flow3_Title_Label, Flow3_Type_CB, Flow3_Manufacturer_CB, Flow3_Modification_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Flow4_CB, Flow4_GB, Flow4_Title_Label, Flow4_Type_CB, Flow4_Manufacturer_CB, Flow4_Modification_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Flow5_CB, Flow5_GB, Flow5_Title_Label, Flow5_Type_CB, Flow5_Manufacturer_CB, Flow5_Modification_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB));
-            _flowMeters.Add(new FlowMeterSection(Flow6_CB, Flow6_GB, Flow6_Title_Label, Flow6_Type_CB, Flow6_Manufacturer_CB, Flow6_Modification_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB));
+            _flowMeters.Add(new FlowMeterSection(Flow1CheckBox, Flow1GroupBox, Flow1TitleLabel, Flow1TypeComboBox, Flow1ManufacturerComboBox, Flow1ModificationComboBox, Flow1ManufactureDateDateTimePicker, Flow1RegistrationNumberTextBox));
+            _flowMeters.Add(new FlowMeterSection(Flow2CheckBox, Flow2GroupBox, Flow2TitleLabel, Flow2TypeComboBox, Flow2ManufacturerComboBox, Flow2ModificationComboBox, Flow2ManufactureDateDateTimePicker, Flow2RegistrationNumberTextBox));
+            _flowMeters.Add(new FlowMeterSection(Flow3CheckBox, Flow3GroupBox, Flow3TitleLabel, Flow3TypeComboBox, Flow3ManufacturerComboBox, Flow3ModificationComboBox, Flow3ManufactureDateDateTimePicker, Flow3RegistrationNumberTextBox));
+            _flowMeters.Add(new FlowMeterSection(Flow4CheckBox, Flow4GroupBox, Flow4TitleLabel, Flow4TypeComboBox, Flow4ManufacturerComboBox, Flow4ModificationComboBox, Flow4ManufactureDateDateTimePicker, Flow4RegistrationNumberTextBox));
+            _flowMeters.Add(new FlowMeterSection(Flow5CheckBox, Flow5GroupBox, Flow5TitleLabel, Flow5TypeComboBox, Flow5ManufacturerComboBox, Flow5ModificationComboBox, Flow5ManufactureDateDateTimePicker, Flow5RegistrationNumberTextBox));
+            _flowMeters.Add(new FlowMeterSection(Flow6CheckBox, Flow6GroupBox, Flow6TitleLabel, Flow6TypeComboBox, Flow6ManufacturerComboBox, Flow6ModificationComboBox, Flow6ManufactureDateDateTimePicker, Flow6RegistrationNumberTextBox));
         }
 
-        private async void MetersSetupForm_Load(object sender, EventArgs e)
+        private async void MetersSetupFormLoad(object sender, EventArgs e)
         {
             if (DesignMode)
             {
@@ -48,7 +48,7 @@ namespace PoverkaWinForms.Forms.Verifier
 
             foreach (var meter in _flowMeters)
             {
-                FlowCB_CheckedChanged(meter.CheckBox, EventArgs.Empty);
+                FlowCheckBoxCheckedChanged(meter.CheckBox, EventArgs.Empty);
             }
 
             await _meterTypeService.GetAllAsync(string.Empty, 10);
@@ -106,7 +106,7 @@ namespace PoverkaWinForms.Forms.Verifier
             _previousTexts.Remove(combo);
         }
 
-        private void TypeCB_SelectedIndexChanged(object? sender, EventArgs e)
+        private void TypeComboBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
             {
@@ -208,7 +208,7 @@ namespace PoverkaWinForms.Forms.Verifier
             registrationNumberTextBox.Text = modification?.RegistrationNumber ?? string.Empty;
         }
 
-        private void ModificationCB_TextUpdate(object? sender, EventArgs e)
+        private void ModificationComboBoxTextUpdate(object? sender, EventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
             {
@@ -241,7 +241,7 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        private void ModificationCB_KeyDown(object? sender, KeyEventArgs e)
+        private void ModificationComboBoxKeyDown(object? sender, KeyEventArgs e)
         {
             if (sender is not ComboBox combo)
             {
@@ -263,7 +263,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void MeterTypeCB_KeyDown(object? sender, KeyEventArgs e)
+        private void MeterTypeComboBoxKeyDown(object? sender, KeyEventArgs e)
         {
             if (sender is not ComboBox combo)
             {
@@ -332,7 +332,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private async void MeterTypeCB_KeyUp(object? sender, KeyEventArgs e)
+        private async void MeterTypeComboBoxKeyUp(object? sender, KeyEventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
             {
@@ -368,7 +368,7 @@ namespace PoverkaWinForms.Forms.Verifier
             catch (TaskCanceledException) { }
         }
 
-        private async void MeterTypeCB_Click(object? sender, EventArgs e)
+        private async void MeterTypeComboBoxClick(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo)
             {
@@ -377,7 +377,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private async void ManufacturerCB_KeyUp(object? sender, KeyEventArgs e)
+        private async void ManufacturerComboBoxKeyUp(object? sender, KeyEventArgs e)
         {
             if (_updating || sender is not ComboBox combo)
             {
@@ -413,7 +413,7 @@ namespace PoverkaWinForms.Forms.Verifier
             catch (TaskCanceledException) { }
         }
 
-        private async void ManufacturerCB_Click(object? sender, EventArgs e)
+        private async void ManufacturerComboBoxClick(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo)
             {
@@ -422,7 +422,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void ManufacturerCB_SelectedIndexChanged(object? sender, EventArgs e)
+        private void ManufacturerComboBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
             {
@@ -430,7 +430,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void ManufactureDateDTP_ValueChanged(object? sender, EventArgs e)
+        private void ManufactureDateDateTimePickerValueChanged(object? sender, EventArgs e)
         {
             if (sender is DateTimePicker picker && picker.Tag is FlowMeterSection meter)
             {
@@ -438,7 +438,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private async void ModificationCB_Click(object? sender, EventArgs e)
+        private async void ModificationComboBoxClick(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
             {
@@ -447,7 +447,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private void ModificationCB_SelectedIndexChanged(object? sender, EventArgs e)
+        private void ModificationComboBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo && combo.Tag is FlowMeterSection meter)
             {
@@ -455,7 +455,7 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        private async void FlowCB_CheckedChanged(object? sender, EventArgs e)
+        private async void FlowCheckBoxCheckedChanged(object? sender, EventArgs e)
         {
             if (sender is CheckBox checkBox && checkBox.Tag is FlowMeterSection meter)
             {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -114,16 +114,16 @@ namespace PoverkaWinForms.Forms.Verifier
             }
         }
 
-        internal async Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
+        private async Task PopulateComboAsync<T>(ComboBox combo, string search, int? limit, bool dropDown, Func<string, int?, Task<List<T>>> fetch, string displayMember, string valueMember)
         {
-            var items = await _meterTypeService.GetAllAsync(search, limit);
+            var items = await fetch(search, limit);
 
             var selStart = combo.SelectionStart;
             _updating = true;
             combo.BeginUpdate();
             combo.DataSource = items;
-            combo.DisplayMember = nameof(MeterTypeDto.Type);
-            combo.ValueMember = nameof(MeterTypeDto.Id);
+            combo.DisplayMember = displayMember;
+            combo.ValueMember = valueMember;
             combo.SelectedIndex = -1;
             combo.Text = search;
             combo.SelectionStart = selStart;
@@ -141,32 +141,9 @@ namespace PoverkaWinForms.Forms.Verifier
             _updating = false;
         }
 
-        internal async Task PopulateManufacturersAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false)
-        {
-            var items = await _manufacturerService.GetAllAsync(search, limit);
+        internal Task PopulateMeterTypesAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false) => PopulateComboAsync(combo, search, limit, dropDown, _meterTypeService.GetAllAsync, nameof(MeterTypeDto.Type), nameof(MeterTypeDto.Id));
 
-            var selStart = combo.SelectionStart;
-            _updating = true;
-            combo.BeginUpdate();
-            combo.DataSource = items;
-            combo.DisplayMember = nameof(ManufacturerDto.Name);
-            combo.ValueMember = nameof(ManufacturerDto.Id);
-            combo.SelectedIndex = -1;
-            combo.Text = search;
-            combo.SelectionStart = selStart;
-            combo.SelectionLength = 0;
-            combo.EndUpdate();
-            _typedTexts[combo] = search;
-
-            if (dropDown)
-            {
-                combo.DroppedDown = true;
-                Cursor.Current = Cursors.Default;
-                Cursor.Show();
-            }
-
-            _updating = false;
-        }
+        internal Task PopulateManufacturersAsync(ComboBox combo, string search, int? limit = null, bool dropDown = false) => PopulateComboAsync(combo, search, limit, dropDown, _manufacturerService.GetAllAsync, nameof(ManufacturerDto.Name), nameof(ManufacturerDto.Id));
 
         private async Task PopulateModificationsAsync(ComboBox modificationCombo, ComboBox meterTypeCombo, ComboBox manufacturerCombo, DateTimePicker datePicker, TextBox registrationNumberTextBox)
         {

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -18,6 +18,7 @@ namespace PoverkaWinForms.Forms.Verifier
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
         private readonly Dictionary<ComboBox, List<ModificationDto>> _modifications = new();
         private readonly Dictionary<ComboBox, string> _previousTexts = new();
+        private readonly Dictionary<ComboBox, (ComboBox meterType, ComboBox manufacturer, DateTimePicker datePicker, TextBox registrationNumber)> _modificationSources = new();
 
         public MetersSetupForm(
             MeterTypeService meterTypeService,
@@ -29,6 +30,13 @@ namespace PoverkaWinForms.Forms.Verifier
             _manufacturerService = manufacturerService;
             _modificationService = modificationService;
             InitializeComponent();
+
+            _modificationSources[Flow1_Modification_CB] = (Flow1_Name_SI_CB, Flow1_GosReestr_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB);
+            _modificationSources[Flow2_Modification_CB] = (Flow2_Name_SI_CB, Flow2_GosReestr_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB);
+            _modificationSources[Flow3_Modification_CB] = (Flow3_Name_SI_CB, Flow3_GosReestr_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB);
+            _modificationSources[Flow4_Modification_CB] = (Flow4_Name_SI_CB, Flow4_GosReestr_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB);
+            _modificationSources[Flow5_Modification_CB] = (Flow5_Name_SI_CB, Flow5_GosReestr_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB);
+            _modificationSources[Flow6_Modification_CB] = (Flow6_Name_SI_CB, Flow6_GosReestr_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB);
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
@@ -463,76 +471,19 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void button1_Click(object sender, EventArgs e) { }
 
-        private async void Flow1_Modification_CB_Click(object? sender, EventArgs e)
+        private async void ModificationCB_Click(object? sender, EventArgs e)
         {
-            StoreAndClearCombo(Flow1_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow1_Modification_CB,
-                Flow1_Name_SI_CB,
-                Flow1_GosReestr_CB,
-                Flow1_ManufactureDate_DTP,
-                Flow1_RegistrationNumber_TB
-            );
-        }
-
-        private async void Flow2_Modification_CB_Click(object? sender, EventArgs e)
-        {
-            StoreAndClearCombo(Flow2_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow2_Modification_CB,
-                Flow2_Name_SI_CB,
-                Flow2_GosReestr_CB,
-                Flow2_ManufactureDate_DTP,
-                Flow2_RegistrationNumber_TB
-            );
-        }
-
-        private async void Flow3_Modification_CB_Click(object? sender, EventArgs e)
-        {
-            StoreAndClearCombo(Flow3_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow3_Modification_CB,
-                Flow3_Name_SI_CB,
-                Flow3_GosReestr_CB,
-                Flow3_ManufactureDate_DTP,
-                Flow3_RegistrationNumber_TB
-            );
-        }
-
-        private async void Flow4_Modification_CB_Click(object? sender, EventArgs e)
-        {
-            StoreAndClearCombo(Flow4_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow4_Modification_CB,
-                Flow4_Name_SI_CB,
-                Flow4_GosReestr_CB,
-                Flow4_ManufactureDate_DTP,
-                Flow4_RegistrationNumber_TB
-            );
-        }
-
-        private async void Flow5_Modification_CB_Click(object? sender, EventArgs e)
-        {
-            StoreAndClearCombo(Flow5_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow5_Modification_CB,
-                Flow5_Name_SI_CB,
-                Flow5_GosReestr_CB,
-                Flow5_ManufactureDate_DTP,
-                Flow5_RegistrationNumber_TB
-            );
-        }
-
-        private async void Flow6_Modification_CB_Click(object? sender, EventArgs e)
-        {
-            StoreAndClearCombo(Flow6_Modification_CB);
-            await PopulateModificationsAsync(
-                Flow6_Modification_CB,
-                Flow6_Name_SI_CB,
-                Flow6_GosReestr_CB,
-                Flow6_ManufactureDate_DTP,
-                Flow6_RegistrationNumber_TB
-            );
+            if (sender is ComboBox combo && _modificationSources.TryGetValue(combo, out var sources))
+            {
+                StoreAndClearCombo(combo);
+                await PopulateModificationsAsync(
+                    combo,
+                    sources.meterType,
+                    sources.manufacturer,
+                    sources.datePicker,
+                    sources.registrationNumber
+                );
+            }
         }
 
         private void Flow1_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -18,7 +18,6 @@ namespace PoverkaWinForms.Forms.Verifier
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
         private readonly Dictionary<ComboBox, List<ModificationDto>> _modifications = new();
         private readonly Dictionary<ComboBox, string> _previousTexts = new();
-        private readonly Dictionary<ComboBox, (ComboBox meterType, ComboBox manufacturer, DateTimePicker datePicker, TextBox registrationNumber)> _modificationSources = new();
 
         public MetersSetupForm(
             MeterTypeService meterTypeService,
@@ -30,13 +29,6 @@ namespace PoverkaWinForms.Forms.Verifier
             _manufacturerService = manufacturerService;
             _modificationService = modificationService;
             InitializeComponent();
-
-            _modificationSources[Flow1_Modification_CB] = (Flow1_Name_SI_CB, Flow1_GosReestr_CB, Flow1_ManufactureDate_DTP, Flow1_RegistrationNumber_TB);
-            _modificationSources[Flow2_Modification_CB] = (Flow2_Name_SI_CB, Flow2_GosReestr_CB, Flow2_ManufactureDate_DTP, Flow2_RegistrationNumber_TB);
-            _modificationSources[Flow3_Modification_CB] = (Flow3_Name_SI_CB, Flow3_GosReestr_CB, Flow3_ManufactureDate_DTP, Flow3_RegistrationNumber_TB);
-            _modificationSources[Flow4_Modification_CB] = (Flow4_Name_SI_CB, Flow4_GosReestr_CB, Flow4_ManufactureDate_DTP, Flow4_RegistrationNumber_TB);
-            _modificationSources[Flow5_Modification_CB] = (Flow5_Name_SI_CB, Flow5_GosReestr_CB, Flow5_ManufactureDate_DTP, Flow5_RegistrationNumber_TB);
-            _modificationSources[Flow6_Modification_CB] = (Flow6_Name_SI_CB, Flow6_GosReestr_CB, Flow6_ManufactureDate_DTP, Flow6_RegistrationNumber_TB);
         }
 
         private async void MetersSetupForm_Load(object sender, EventArgs e)
@@ -367,7 +359,7 @@ namespace PoverkaWinForms.Forms.Verifier
             catch (TaskCanceledException) { }
         }
 
-        private async void MeterTypeCB_DropDown(object? sender, EventArgs e)
+        private async void MeterTypeCB_Click(object? sender, EventArgs e)
         {
             if (sender is ComboBox combo)
             {
@@ -473,16 +465,38 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private async void ModificationCB_Click(object? sender, EventArgs e)
         {
-            if (sender is ComboBox combo && _modificationSources.TryGetValue(combo, out var sources))
+            if (sender is ComboBox combo)
             {
                 StoreAndClearCombo(combo);
-                await PopulateModificationsAsync(
-                    combo,
-                    sources.meterType,
-                    sources.manufacturer,
-                    sources.datePicker,
-                    sources.registrationNumber
-                );
+
+                var flow = combo.Name.Split('_')[0];
+
+                var meterType = Controls
+                    .Find($"{flow}_Name_SI_CB", true)
+                    .FirstOrDefault() as ComboBox;
+
+                var manufacturer = Controls
+                    .Find($"{flow}_GosReestr_CB", true)
+                    .FirstOrDefault() as ComboBox;
+
+                var datePicker = Controls
+                    .Find($"{flow}_ManufactureDate_DTP", true)
+                    .FirstOrDefault() as DateTimePicker;
+
+                var registrationNumber = Controls
+                    .Find($"{flow}_RegistrationNumber_TB", true)
+                    .FirstOrDefault() as TextBox;
+
+                if (meterType != null && manufacturer != null && datePicker != null && registrationNumber != null)
+                {
+                    await PopulateModificationsAsync(
+                        combo,
+                        meterType,
+                        manufacturer,
+                        datePicker,
+                        registrationNumber
+                    );
+                }
             }
         }
 

--- a/Client/Forms/Verifier/MetersSetupForm.cs
+++ b/Client/Forms/Verifier/MetersSetupForm.cs
@@ -17,6 +17,7 @@ namespace PoverkaWinForms.Forms.Verifier
         private readonly Dictionary<ComboBox, CancellationTokenSource> _searchTokens = new();
         private readonly Dictionary<ComboBox, string> _typedTexts = new();
         private readonly Dictionary<ComboBox, List<ModificationDto>> _modifications = new();
+        private readonly Dictionary<ComboBox, string> _previousTexts = new();
 
         public MetersSetupForm(
             MeterTypeService meterTypeService,
@@ -48,11 +49,44 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void ResetModifications(ComboBox modificationCombo, TextBox registrationNumberTextBox)
         {
+            if (_updating)
+                return;
+
             modificationCombo.DataSource = null;
             modificationCombo.Items.Clear();
             modificationCombo.SelectedIndex = -1;
             _modifications.Remove(modificationCombo);
             registrationNumberTextBox.Text = string.Empty;
+        }
+
+        private void StoreAndClearCombo(ComboBox combo)
+        {
+            if (string.IsNullOrEmpty(combo.Text))
+                return;
+
+            _updating = true;
+            _previousTexts[combo] = combo.Text;
+            combo.Text = string.Empty;
+            combo.SelectionStart = 0;
+            combo.SelectionLength = 0;
+            _updating = false;
+        }
+
+        private void RestoreComboText(object? sender, EventArgs e)
+        {
+            if (_updating || sender is not ComboBox combo)
+                return;
+
+            if (string.IsNullOrEmpty(combo.Text) && _previousTexts.TryGetValue(combo, out var text))
+            {
+                _updating = true;
+                combo.Text = text;
+                combo.SelectionStart = combo.Text.Length;
+                combo.SelectionLength = 0;
+                _updating = false;
+            }
+
+            _previousTexts.Remove(combo);
         }
 
         private void Flow1_Name_SI_CB_SelectedIndexChanged(object sender, EventArgs e) =>
@@ -326,7 +360,7 @@ namespace PoverkaWinForms.Forms.Verifier
         {
             if (sender is ComboBox combo)
             {
-                combo.SelectionLength = 0;
+                StoreAndClearCombo(combo);
                 await PopulateMeterTypesAsync(
                     combo,
                     combo.Text,
@@ -374,7 +408,7 @@ namespace PoverkaWinForms.Forms.Verifier
         {
             if (sender is ComboBox combo)
             {
-                combo.SelectionLength = 0;
+                StoreAndClearCombo(combo);
                 await PopulateManufacturersAsync(
                     combo,
                     combo.Text,
@@ -426,7 +460,9 @@ namespace PoverkaWinForms.Forms.Verifier
 
         private void button1_Click(object sender, EventArgs e) { }
 
-        private async void Flow1_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow1_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow1_Modification_CB);
             await PopulateModificationsAsync(
                 Flow1_Modification_CB,
                 Flow1_Name_SI_CB,
@@ -434,8 +470,11 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow1_ManufactureDate_DTP,
                 Flow1_RegistrationNumber_TB
             );
+        }
 
-        private async void Flow2_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow2_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow2_Modification_CB);
             await PopulateModificationsAsync(
                 Flow2_Modification_CB,
                 Flow2_Name_SI_CB,
@@ -443,8 +482,11 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow2_ManufactureDate_DTP,
                 Flow2_RegistrationNumber_TB
             );
+        }
 
-        private async void Flow3_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow3_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow3_Modification_CB);
             await PopulateModificationsAsync(
                 Flow3_Modification_CB,
                 Flow3_Name_SI_CB,
@@ -452,8 +494,11 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow3_ManufactureDate_DTP,
                 Flow3_RegistrationNumber_TB
             );
+        }
 
-        private async void Flow4_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow4_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow4_Modification_CB);
             await PopulateModificationsAsync(
                 Flow4_Modification_CB,
                 Flow4_Name_SI_CB,
@@ -461,8 +506,11 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow4_ManufactureDate_DTP,
                 Flow4_RegistrationNumber_TB
             );
+        }
 
-        private async void Flow5_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow5_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow5_Modification_CB);
             await PopulateModificationsAsync(
                 Flow5_Modification_CB,
                 Flow5_Name_SI_CB,
@@ -470,8 +518,11 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow5_ManufactureDate_DTP,
                 Flow5_RegistrationNumber_TB
             );
+        }
 
-        private async void Flow6_Modification_CB_Click(object? sender, EventArgs e) =>
+        private async void Flow6_Modification_CB_Click(object? sender, EventArgs e)
+        {
+            StoreAndClearCombo(Flow6_Modification_CB);
             await PopulateModificationsAsync(
                 Flow6_Modification_CB,
                 Flow6_Name_SI_CB,
@@ -479,6 +530,7 @@ namespace PoverkaWinForms.Forms.Verifier
                 Flow6_ManufactureDate_DTP,
                 Flow6_RegistrationNumber_TB
             );
+        }
 
         private void Flow1_Modification_CB_SelectedIndexChanged(object sender, EventArgs e) =>
             UpdateRegistrationNumber(Flow1_Modification_CB, Flow1_RegistrationNumber_TB);


### PR DESCRIPTION
## Summary
- clear Type/Manufacturer/Modification combos when expanding
- restore previous value if no changes were made

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b48a4e1fc883319409ef719c30ab75